### PR TITLE
Specify english when querying since we specify it creating the index.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -56,7 +56,7 @@ class SoQLAnalysisSqlizer(analysis: SoQLAnalysis[UserColumnId, SoQLType], tableN
       PostgresUniverseCommon.searchVector(allColumnReps) match {
         case Some(sv) =>
           val andOrWhere = if (where.isDefined) " AND" else " WHERE"
-          val fts = s"$andOrWhere $sv @@ plainto_tsquery($searchSql)"
+          val fts = s"$andOrWhere $sv @@ plainto_tsquery('english', $searchSql)"
           ParametricSql(fts, searchSetParams)
         case None =>
           ParametricSql("", setParamsWhere)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
@@ -170,7 +170,7 @@ class SqlizerTest extends FunSuite with Matchers {
   test("search") {
     val soql = "select id search 'oNe Two'"
     val ParametricSql(sql, setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT id FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery(?)")
+    sql should be ("SELECT id FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery('english', ?)")
     setParams.length should be (1)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("oNe Two"))


### PR DESCRIPTION
If not specified, postgres uses its default as set in default_text_search_config.  In RDS this is
set to simple whereas in other environments it gets set to english based on the locale.

http://www.postgresql.org/docs/9.4/static/runtime-config-client.html#GUC-DEFAULT-TEXT-SEARCH-CONFIG

The result was, for example, 'vancouver' getting indexed as 'vancouv' but the same wasn't happening
at query time so no results were found.