### PR TITLE
Enable blob type

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
@@ -108,6 +108,7 @@ object SqlFunctions {
     TextToFixedTimestamp -> formatCall("%s::timestamp with time zone") _,
     TextToFloatingTimestamp -> formatCall("%s::timestamp") _, // without time zone
     TextToMoney -> formatCall("%s::numeric") _,
+    TextToBlob -> passthrough,
 
     TextToBool -> formatCall("%s::boolean") _,
     BoolToText -> formatCall("%s::varchar") _,

--- a/common-pg/src/main/scala/com/socrata/pg/store/index/Indexable.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/index/Indexable.scala
@@ -107,6 +107,8 @@ trait TimestampLikeIndexable[T] extends BaseIndexable[T] { this: SqlColumnCommon
 
 trait BooleanIndexable[T] extends BaseIndexable[T] { this: SqlColumnCommonRep[T] => }
 
+trait BlobIndexable[T] extends BaseIndexable[T] { this: SqlColumnCommonRep[T] => }
+
 trait GeoIndexable[T] extends BaseIndexable[T] { this: SqlColumnCommonRep[T] =>
 
   override def createIndex(tableName: String, tablespace: String): Option[String] = {
@@ -154,6 +156,7 @@ object SoQLIndexableRep {
     SoQLDouble -> (base => new DoubleRep(base) with NumberLikeIndexable[SoQLType]),
     SoQLObject -> (base => new ObjectRep(base) with NoIndex[SoQLType]), // TODO: Revisit index need
     SoQLArray -> (base => new ArrayRep(base) with NoIndex[SoQLType]), // TODO: Revisit index need
+    SoQLBlob -> (base => new BlobRep(base) with BlobIndexable[SoQLType]), // TODO: Revisit index need
     SoQLPoint -> (base =>
       new GeometryLikeRep[Point](
         SoQLPoint,

--- a/common-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUniverseTestBase.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUniverseTestBase.scala
@@ -200,5 +200,5 @@ trait PGSecondaryUniverseTestBase extends FunSuiteLike with Matchers with Before
   /**
    * TODO: Remove types in this set once support is added.
    */
-  val UnsupportedTypes = Set("json", "blob").map(TypeName(_))
+  val UnsupportedTypes = Set("json").map(TypeName(_))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "0.8.7"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "0.7.17"
+    val dataCoordinator = "0.7.21"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.2.0"
     val metricsJetty = "3.1.0"

--- a/soql-server-pg/src/test/resources/fixtures/group-case.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-case.json
@@ -1,4 +1,5 @@
-[{ "category" : "Advanced", "count" : 1}
+[{ "category" : null, "count" : 1}
+,{ "category" : "Advanced", "count" : 1}
 ,{ "category" : "Beginner", "count" : 3 }
 ,{ "category" : "Intermediate", "count" : 10 }
 ]

--- a/soql-server-pg/src/test/resources/fixtures/group-floatingtimestamp-trunc-y.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-floatingtimestamp-trunc-y.json
@@ -3,5 +3,5 @@
 ,{"count":2,"date_trunc_y_available":"2011-01-01T00:00:00.000"}
 ,{"count":3,"date_trunc_y_available":"2012-01-01T00:00:00.000"}
 ,{"count":2,"date_trunc_y_available":"2013-01-01T00:00:00.000"}
-,{"count":5,"date_trunc_y_available":null}
+,{"count":6,"date_trunc_y_available":null}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/group-text-expr.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-text-expr.json
@@ -12,7 +12,7 @@
     "brand_made": "ISRAEL'S APCO"
   },
   {
-    "count_name": 5,
+    "count_name": 6,
     "brand_made": null
   }
 ]

--- a/soql-server-pg/src/test/resources/fixtures/group-text-order-count.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-text-order-count.json
@@ -8,23 +8,27 @@
     "count_name": 3
   },
   {
+    "umake": "GIN",
+    "count_name": 2
+  },
+  {
     "umake": "OZONE",
     "count_name": 2
   },
   {
-    "umake": "GIN",
-    "count_name": 2
+    "umake": "A THING",
+    "count_name": 1
   },
   {
     "umake": "FOXTROT",
     "count_name": 1
   },
   {
-    "umake": "YANKEE",
+    "umake": "HOTEL",
     "count_name": 1
   },
   {
-    "umake": "HOTEL",
+    "umake": "YANKEE",
     "count_name": 1
   }
 ]

--- a/soql-server-pg/src/test/resources/fixtures/group-text-order-count.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-text-order-count.json
@@ -16,7 +16,7 @@
     "count_name": 2
   },
   {
-    "umake": "A THING",
+    "umake": "ATHING",
     "count_name": 1
   },
   {

--- a/soql-server-pg/src/test/resources/fixtures/group-text.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-text.json
@@ -4,6 +4,10 @@
     "count_name": 4
   },
   {
+    "umake": "A THING",
+    "count_name": 1
+  },
+  {
     "umake": "FOXTROT",
     "count_name": 1
   },

--- a/soql-server-pg/src/test/resources/fixtures/group-text.json
+++ b/soql-server-pg/src/test/resources/fixtures/group-text.json
@@ -4,7 +4,7 @@
     "count_name": 4
   },
   {
-    "umake": "A THING",
+    "umake": "ATHING",
     "count_name": 1
   },
   {

--- a/soql-server-pg/src/test/resources/fixtures/mutate-create.json
+++ b/soql-server-pg/src/test/resources/fixtures/mutate-create.json
@@ -23,6 +23,7 @@
 { c: "add column", id: "multipoint", type: "multipoint" },
 { c: "add column", id: "line", type: "line" },
 { c: "add column", id: "polygon", type: "polygon" },
+{ c: "add column", id: "blob", type: "blob" },
 { c: "row data" },
 {"code":"14200","make":"APCO","name":"Karma","class":"DHV-1","v_min":20,"v_trim":36,"v_max":45,"aspect_ratio":4.9,"aspect_ratio_project":3.5,"line_length":412,"price":2500,"three_liner":false,"size":"Small","available":"2008-08-01T15:12:34","certified":"2008-03-01T12:11:22-05","point":"POINT(34.89265 32.505781)","multipolygon":"MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)))","country":"Israel", "color": ["Red", "Yellow", "Royal Blue", "Purple", "Turquoise"],"spec": {"root_chord": 2.84, "tip_chord": 0.48,  "weight" : 6.0 }},
 {"code":"14210","make":"APCO","name":"Karma SP","class":"EN-A","v_min":20,"v_trim":37,"v_max":46,"aspect_ratio":4.9,"aspect_ratio_project":3.5,"line_length":412,"price":2650,"three_liner":false,"size":"Small","available":"2010-08-01T15:12:34","certified":"2010-03-01T12:11:22-06","point":"POINT(34.89265 32.505781)","multipolygon":"MULTIPOLYGON(((1 0,2 0,2 1,1 1,1 0)))","country":"Israel", "color": ["Tangerine","Patriot", "Brasiliera", "Lagoon", "Flame"],"spec": {"root_chord": 2.84, "tip_chord": 0.48,  "weight" : 5.4 }},
@@ -37,6 +38,7 @@
 {"code":"SPRINT-EVO","make":"GIN","name":"Sprint Evo","class":"EN-B","point":"POINT(11.574601 48.148484)","multipolygon":"MULTIPOLYGON(((11.578791 48.144026,11.582921 48.143088,11.582181 48.141649,11.578136 48.142515,11.578791 48.144026)))"},
 {"code":"FOO","make":"YANKEE","name":"Yankee","class":"EN-B","line":"LINESTRING(0.123456 0.123456, 0.123456 10.123456, 10.123456 10.123456)"},
 {"code":"BAR","make":"HOTEL","name":"Hotel","class":"EN-B","multipoint":"MULTIPOINT(0.123456 0.123456, 0.123456 10.123456)"},
-{"code":"BAZ","make":"FOXTROT","name":"Foxtrot","class":"EN-B","polygon":"POLYGON((0.123456 0.123456, 0.123456 10.123456, 10.123456 10.123456, 0.123456 0.123456))"}
+{"code":"BAZ","make":"FOXTROT","name":"Foxtrot","class":"EN-B","polygon":"POLYGON((0.123456 0.123456, 0.123456 10.123456, 10.123456 10.123456, 0.123456 0.123456))"},
+{"code":"GNU","make":"A THING","name":"Richard M. Stallman","blob":"some-blob-identifier"}
 ]
 

--- a/soql-server-pg/src/test/resources/fixtures/mutate-create.json
+++ b/soql-server-pg/src/test/resources/fixtures/mutate-create.json
@@ -39,6 +39,6 @@
 {"code":"FOO","make":"YANKEE","name":"Yankee","class":"EN-B","line":"LINESTRING(0.123456 0.123456, 0.123456 10.123456, 10.123456 10.123456)"},
 {"code":"BAR","make":"HOTEL","name":"Hotel","class":"EN-B","multipoint":"MULTIPOINT(0.123456 0.123456, 0.123456 10.123456)"},
 {"code":"BAZ","make":"FOXTROT","name":"Foxtrot","class":"EN-B","polygon":"POLYGON((0.123456 0.123456, 0.123456 10.123456, 10.123456 10.123456, 0.123456 0.123456))"},
-{"code":"GNU","make":"A THING","name":"Richard M. Stallman","blob":"some-blob-identifier"}
+{"code":"GNU","make":"ATHING","name":"Richard M. Stallman","blob":"some-blob-identifier"}
 ]
 

--- a/soql-server-pg/src/test/resources/fixtures/result.json
+++ b/soql-server-pg/src/test/resources/fixtures/result.json
@@ -2,6 +2,7 @@
 ,{"make":"APCO","name":"Karma SP"}
 ,{"make":"APCO","name":"Vista II SP"}
 ,{"make":"APCO","name":"Zefira"}
+,{"make":"A THING","name":"Richard M. Stallman"}
 ,{"make":"FOXTROT","name":"Foxtrot"}
 ,{"make":"GIN","name":"Atlas"}
 ,{"make":"GIN","name":"Sprint Evo"}

--- a/soql-server-pg/src/test/resources/fixtures/result.json
+++ b/soql-server-pg/src/test/resources/fixtures/result.json
@@ -2,7 +2,7 @@
 ,{"make":"APCO","name":"Karma SP"}
 ,{"make":"APCO","name":"Vista II SP"}
 ,{"make":"APCO","name":"Zefira"}
-,{"make":"A THING","name":"Richard M. Stallman"}
+,{"make":"ATHING","name":"Richard M. Stallman"}
 ,{"make":"FOXTROT","name":"Foxtrot"}
 ,{"make":"GIN","name":"Atlas"}
 ,{"make":"GIN","name":"Sprint Evo"}

--- a/soql-server-pg/src/test/resources/fixtures/select-signed_magnitude_10.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-signed_magnitude_10.json
@@ -7,6 +7,7 @@
   { "name" : "Karma", "line_length" : 412, "signed_magnitude_10_line_length" : 3, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Karma SP", "line_length" : 412, "signed_magnitude_10_line_length" : 3, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Mescal", "line_length" : 295, "signed_magnitude_10_line_length" : 3, "z" : 0, "p" : 1, "n" : -1 },
+  { "name" : "Richard M. Stallman", "line_length" : null, "signed_magnitude_10_line_length" : null, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Rush", "line_length" : -1, "signed_magnitude_10_line_length" : -1, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Sprint Evo", "line_length" : null, "signed_magnitude_10_line_length" : null, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Tequila", "line_length" : -1, "signed_magnitude_10_line_length" : -1, "z" : 0, "p" : 1, "n" : -1 },

--- a/soql-server-pg/src/test/resources/fixtures/select-signed_magnitude_linear.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-signed_magnitude_linear.json
@@ -7,6 +7,7 @@
   { "name" : "Karma", "line_length" : 412, "signed_magnitude_linear_line_length_10" : 42, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Karma SP", "line_length" : 412, "signed_magnitude_linear_line_length_10" : 42, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Mescal", "line_length" : 295, "signed_magnitude_linear_line_length_10" : 30, "z" : 0, "p" : 1, "n" : -1 },
+  { "name" : "Richard M. Stallman", "line_length" : null, "signed_magnitude_linear_line_length_10" : null, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Rush", "line_length" : -1, "signed_magnitude_linear_line_length_10" : -1, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Sprint Evo", "line_length" : null, "signed_magnitude_linear_line_length_10" : null, "z" : 0, "p" : 1, "n" : -1 },
   { "name" : "Tequila", "line_length" : -1, "signed_magnitude_linear_line_length_10" : -1, "z" : 0, "p" : 1, "n" : -1 },

--- a/soql-server-pg/src/test/resources/fixtures/where-conv-txt2blob.json
+++ b/soql-server-pg/src/test/resources/fixtures/where-conv-txt2blob.json
@@ -1,0 +1,2 @@
+[{"code":"GNU","blob":"some-blob-identifier"}
+]

--- a/soql-server-pg/src/test/resources/fixtures/where-null-isnull.json
+++ b/soql-server-pg/src/test/resources/fixtures/where-null-isnull.json
@@ -36,7 +36,7 @@
     "v_max_is_null": true,
     "name": "Richard M. Stallman",
     "color_is_null": true,
-    "make": "A THING",
+    "make": "ATHING",
     "certified_is_null": true,
     "available_is_null": true,
     "three_liner_is_null": true,

--- a/soql-server-pg/src/test/resources/fixtures/where-null-isnull.json
+++ b/soql-server-pg/src/test/resources/fixtures/where-null-isnull.json
@@ -34,6 +34,17 @@
   },
   {
     "v_max_is_null": true,
+    "name": "Richard M. Stallman",
+    "color_is_null": true,
+    "make": "A THING",
+    "certified_is_null": true,
+    "available_is_null": true,
+    "three_liner_is_null": true,
+    "spec_is_null": true,
+    "size_is_null": true
+  },
+  {
+    "v_max_is_null": true,
     "name": "Sprint Evo",
     "color_is_null": true,
     "make": "GIN",

--- a/soql-server-pg/src/test/resources/fixtures/where-str-ne.json
+++ b/soql-server-pg/src/test/resources/fixtures/where-str-ne.json
@@ -4,6 +4,7 @@
 ,{"make":"FOXTROT","name":"Foxtrot"}
 ,{"make":"HOTEL","name":"Hotel"}
 ,{"make":"Skywalk","name":"Mescal"}
+,{"make":"A THING","name":"Richard M. Stallman"}
 ,{"make":"OZONE","name":"Rush"}
 ,{"make":"GIN","name":"Sprint Evo"}
 ,{"make":"Skywalk","name":"Tequila"}

--- a/soql-server-pg/src/test/resources/fixtures/where-str-ne.json
+++ b/soql-server-pg/src/test/resources/fixtures/where-str-ne.json
@@ -4,7 +4,7 @@
 ,{"make":"FOXTROT","name":"Foxtrot"}
 ,{"make":"HOTEL","name":"Hotel"}
 ,{"make":"Skywalk","name":"Mescal"}
-,{"make":"A THING","name":"Richard M. Stallman"}
+,{"make":"ATHING","name":"Richard M. Stallman"}
 ,{"make":"OZONE","name":"Rush"}
 ,{"make":"GIN","name":"Sprint Evo"}
 ,{"make":"Skywalk","name":"Tequila"}

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLConversionFunctionsTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLConversionFunctionsTest.scala
@@ -31,6 +31,10 @@ class SoQLConversionFunctionsTest extends SoQLTest {
     compareSoqlResult("select name, make::text as make_ident, code where code::number=14200 and upper(name) = 'KARMA'", "where-conv-txt2txt.json")
   }
 
+  test("text::blob") {
+    compareSoqlResult("select code, blob where blob='some-blob-identifier'", "where-conv-txt2blob.json")
+  }
+
   test("num::num") {
     compareSoqlResult("select make, name, v_max::number as v_max_ident where make = 'APCO' order by name", "where-conv-num2num.json")
   }

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLGroupTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLGroupTest.scala
@@ -14,11 +14,11 @@ class SoQLGroupTest extends SoQLTest {
 
 
   test("group by text order by count") {
-    compareSoqlResult("select upper(make) as umake, count(name) group by upper(make) order by count(name) desc", "group-text-order-count.json")
+    compareSoqlResult("select upper(make) as umake, count(name) group by upper(make) order by count(name) desc, umake", "group-text-order-count.json")
   }
 
   test("group by text order by count ci") {
-    compareSoqlResult("select make as umake, count(name) group by make order by count(name) desc", "group-text-order-count.json", caseSensitivity = CaseInsensitive)
+    compareSoqlResult("select make as umake, count(name) group by make order by count(name) desc, umake", "group-text-order-count.json", caseSensitivity = CaseInsensitive)
   }
 
   test("group by text, numeric fn where having") {

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLLimitOffsetTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLLimitOffsetTest.scala
@@ -3,7 +3,7 @@ package com.socrata.pg.server
 class SoQLLimitOffsetTest  extends SoQLTest {
 
   test("plain with row count") {
-    compareSoqlResult("select make, name order by name offset 2 limit 5", "limitoffset-plain.json", Some(14))
+    compareSoqlResult("select make, name order by name offset 2 limit 5", "limitoffset-plain.json", Some(15))
   }
 
   test("plain w/o row count") {
@@ -11,11 +11,11 @@ class SoQLLimitOffsetTest  extends SoQLTest {
   }
 
   test("group by with row count") {
-    compareSoqlResult("select make, count(name) where not starts_with(make, 'z') group by make having count(name) > 0 order by make limit 1 offset 4", "limitoffset-group.json", Some(7))
+    compareSoqlResult("select make, count(name) where not starts_with(make, 'z') group by make having count(name) > 0 order by make limit 1 offset 5", "limitoffset-group.json", Some(8))
   }
 
   test("group by w/o row count") {
-    compareSoqlResult("select make, count(name) where not starts_with(make, 'z') group by make having count(name) > 0 order by make limit 1 offset 4", "limitoffset-group.json", None)
+    compareSoqlResult("select make, count(name) where not starts_with(make, 'z') group by make having count(name) > 0 order by make limit 1 offset 5", "limitoffset-group.json", None)
   }
 
   test("search with row count") {

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupDropTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupDropTest.scala
@@ -84,7 +84,7 @@ class RollupDropTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBas
       val expectedTable = if (materialized) 1 else 0
       jdbcColumnCount(pgu.conn, rollupTableName) should be (expectedTable)
       if (materialized) {
-        jdbcRowCount(pgu.conn, rollupTableName) should be (14)
+        jdbcRowCount(pgu.conn, rollupTableName) should be (15)
       }
       pgu.conn.commit()
       rollupTableName

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -36,8 +36,8 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
 
-      jdbcColumnCount(pgu.conn, tableName) should be (21)
-      jdbcRowCount(pgu.conn,tableName) should be (14)
+      jdbcColumnCount(pgu.conn, tableName) should be (22)
+      jdbcRowCount(pgu.conn,tableName) should be (15)
       secondary.shutdown()
     }
   }
@@ -56,7 +56,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
 
       jdbcColumnCount(pgu.conn, tableName) should be (5)
-      jdbcRowCount(pgu.conn,tableName) should be (14)
+      jdbcRowCount(pgu.conn,tableName) should be (15)
       secondary.shutdown()
     }
   }


### PR DESCRIPTION
Blobs are represented by a text column, and there are only two functions
on them: comparing them for equality, and an identity-ish conversion of
text to blob (which is implicitly used on literal string to convert them
to blob values if required).
