### PR TITLE
Make the tests be more flexible about floating-point numbers

### DIFF
--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
@@ -80,7 +80,7 @@ trait PGQueryServerDatabaseTestBase extends DatabaseTestBase with PGSecondaryUni
 
   def approximatelyTheSameAs(expected: JValue) = new BeMatcher[JValue] {
     override def apply(got: JValue): MatchResult =
-      MatchResult(approximatelyEqual(got, expected), got + " did not (approximtely) equal " + expected, got + " (approximtely) equalled " + expected)
+      MatchResult(approximatelyEqual(got, expected), got + " did not (approximately) equal " + expected, got + " (approximately) equalled " + expected)
 
     private def approximatelyEqual(got: JValue, expected: JValue): Boolean = (got, expected) match {
       case (gotN: JNumber, expectedN: JNumber) =>


### PR DESCRIPTION
By accepting a number if it's within 0.001% of the expected value