### PR TITLE
EN-158: Updates to use new version of data-coordinator

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20160107-create-computation-strategy-map.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20160107-create-computation-strategy-map.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20160107-create-computation-strategy-map">
+        <sql>
+            CREATE TABLE computation_strategy_map (
+            column_system_id      BIGINT          NOT NULL,
+            copy_system_id        BIGINT          NOT NULL,
+            strategy_type         TEXT            NOT NULL,
+            recompute             BOOLEAN         NOT NULL,
+            source_column_ids     TEXT[]          NOT NULL,
+            parameters            TEXT            NOT NULL,
+
+            PRIMARY KEY (column_system_id, copy_system_id),
+            FOREIGN KEY (column_system_id, copy_system_id) REFERENCES column_map (system_id, copy_system_id)
+            )
+        </sql>
+        <rollback>
+            <sql>
+                DROP TABLE computation_strategy_map
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20160107-create-computation-strategy-map.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20160107-create-computation-strategy-map.xml
@@ -9,7 +9,6 @@
             column_system_id      BIGINT          NOT NULL,
             copy_system_id        BIGINT          NOT NULL,
             strategy_type         TEXT            NOT NULL,
-            recompute             BOOLEAN         NOT NULL,
             source_column_ids     TEXT[]          NOT NULL,
             parameters            TEXT            NOT NULL,
 

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20160111-add-column-field-name">
+        <sql>
+            ALTER TABLE column_map ADD COLUMN field_name TEXT NULL,
+            ADD COLUMN field_name_casefolded TEXT NULL, ADD UNIQUE (copy_system_id, field_name);
+        </sql>
+        <rollback>
+            ALTER TABLE column_map DROP COLUMN field_name, DROP COLUMN field_name_casefolded;
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
@@ -5,11 +5,15 @@
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <changeSet author="Alexa Rust" id="20160111-add-column-field-name">
         <sql>
-            ALTER TABLE column_map ADD COLUMN field_name TEXT NULL,
-            ADD COLUMN field_name_casefolded TEXT NULL, ADD UNIQUE (copy_system_id, field_name);
+            ALTER TABLE column_map
+            ADD COLUMN field_name TEXT NULL,
+            ADD COLUMN field_name_casefolded TEXT NULL,
+            ADD UNIQUE (copy_system_id, field_name);
         </sql>
         <rollback>
-            ALTER TABLE column_map DROP COLUMN field_name, DROP COLUMN field_name_casefolded;
+            ALTER TABLE column_map
+            DROP COLUMN field_name,
+            DROP COLUMN field_name_casefolded;
         </rollback>
     </changeSet>
 </databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20160111-add-field-name-columns.xml
@@ -8,7 +8,7 @@
             ALTER TABLE column_map
             ADD COLUMN field_name TEXT NULL,
             ADD COLUMN field_name_casefolded TEXT NULL,
-            ADD UNIQUE (copy_system_id, field_name);
+            ADD UNIQUE (copy_system_id, field_name_casefolded);
         </sql>
         <rollback>
             ALTER TABLE column_map

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -9,5 +9,7 @@
     <include file="com/socrata/pg/store/schema/20140703-create-postgis-extension.xml"/>
     <include file="com/socrata/pg/store/schema/20140629-create-rollup-map.xml"/>
     <include file="com/socrata/pg/store/schema/20150501-add-missing-timezone.xml"/>
+    <include file="com/socrata/pg/store/schema/20160107-create-computation-strategy-map.xml"/>
+    <include file="com/socrata/pg/store/schema/20160111-add-field-name-columns.xml"/>
 
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryLogger.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryLogger.scala
@@ -18,6 +18,10 @@ class PGSecondaryLogger[CT, CV] extends Logger[CT, CV] with Logging {
 
   def columnRemoved(info: ColumnInfo[CT]): Unit = logger.debug("column removed")
 
+  def computationStrategyRemoved(info: ColumnInfo[CT]): Unit = logger.debug("computation strategy removed: " + info)
+
+  def fieldNameUpdated(info: ColumnInfo[CT]): Unit = logger.debug("field name updated: " + info)
+
   def rowIdentifierSet(newIdentifier: ColumnInfo[CT]): Unit = logger.debug("rowIdentifierSet: " + newIdentifier)
 
   def rowIdentifierCleared(oldIdentifier: ColumnInfo[CT]): Unit = logger.debug("rowIdentifierCleared: " + oldIdentifier)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
@@ -74,11 +74,13 @@ object SqlizerTest {
         null,
         new ColumnId(id),
         new UserColumnId(columnName.caseFolded),
+        None,
         typ,
         columnName.caseFolded,
         typ == SoQLID,
         false, // isUserKey
-        typ == SoQLVersion
+        typ == SoQLVersion,
+        None
       )(SoQLTypeContext.typeNamespace, null)
       acc :+ cinfo
   }}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "1.0.8"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "1.0.4"
+    val dataCoordinator = "2.1.3"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.2.0"
     val metricsJetty = "3.1.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "1.0.8"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "2.1.3"
+    val dataCoordinator = "2.1.5-SNAPSHOT"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.2.0"
     val metricsJetty = "3.1.0"

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -327,11 +327,13 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity) exte
             latest,
             cid,
             new UserColumnId(columnName.name),
+            None, // field name
             coreExpr.typ,
             columnName.name,
             coreExpr.typ == SoQLID,
             false, // isUserKey
-            coreExpr.typ == SoQLVersion
+            coreExpr.typ == SoQLVersion,
+            None // computation strategy we aren't actually storing...
           )(SoQLTypeContext.typeNamespace, null) // scalastyle:ignore null
           map + (cid -> cinfo)
       }

--- a/store-pg/docker/Dockerfile
+++ b/store-pg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:1.0.4_4101_a8e81376
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.5-SNAPSHOT_4665_52fb0bcc
 
 # TODO expose JMX
 # EXPOSE

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -267,6 +267,9 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
           ColumnRemovedHandler(pgu, truthCopyInfo, secondaryColInfo)
           val shouldRefreshRollup = refreshRollup || (truthCopyInfo.lifecycleStage == TruthLifecycleStage.Published)
           (rebuildIndex, true, None)
+        case FieldNameUpdated(secondaryColInfo) =>
+          FieldNameUpdatedHandler(pgu, truthCopyInfo, secondaryColInfo)
+          (rebuildIndex, false,  None)
         case RowIdentifierSet(info) =>  // no-op
           (rebuildIndex, true, dataLoader)
         case RowIdentifierCleared(info) =>  // no-op
@@ -347,7 +350,8 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
              schema: ColumnIdMap[SecondaryColumnInfo[SoQLType]],
              cookie: Secondary.Cookie,
              rows: Managed[Iterator[ColumnIdMap[SoQLValue]]],
-             rollups: Seq[RollupInfo]): Secondary.Cookie = {
+             rollups: Seq[RollupInfo],
+             isLatestCopy: Boolean): Secondary.Cookie = {
     // should tell us the new copy number
     // We need to perform some accounting here to make sure readers know a resync is in process
     logger.info("resync (datasetInfo: {}, secondaryCopyInfo: {}, schema: {}, cookie: {})",

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/ColumnCreatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/ColumnCreatedHandler.scala
@@ -19,8 +19,10 @@ case class ColumnCreatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
     secColInfo.systemId,
     truthCopyInfo,
     secColInfo.id, // user column id
+    secColInfo.fieldName,
     secColInfo.typ,
-    physicalColumnBaseBase(secColInfo.id.underlying, isSystemColumnId(secColInfo.id)) // system column id
+    physicalColumnBaseBase(secColInfo.id.underlying, isSystemColumnId(secColInfo.id)), // system column id
+    None // not going to store computation strategies
   )
 
   if (secColInfo.isSystemPrimaryKey) pgu.datasetMapWriter.setSystemPrimaryKey(truthColInfo)

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/FieldNameUpdatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/FieldNameUpdatedHandler.scala
@@ -6,8 +6,8 @@ import com.socrata.datacoordinator.secondary.{ColumnInfo => SecondaryColumnInfo}
 import com.socrata.datacoordinator.truth.metadata.{CopyInfo => TruthCopyInfo, DatasetCopyContext}
 
 case class FieldNameUpdatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
-                                             truthCopyInfo: TruthCopyInfo,
-                                             secColInfo: SecondaryColumnInfo[SoQLType]) {
+                                   truthCopyInfo: TruthCopyInfo,
+                                   secColInfo: SecondaryColumnInfo[SoQLType]) {
   val sLoader = pgu.schemaLoader(new PGSecondaryLogger[SoQLType, SoQLValue])
 
   val truthCopyContext = new DatasetCopyContext[SoQLType](truthCopyInfo, pgu.datasetMapReader.schema(truthCopyInfo))

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/FieldNameUpdatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/FieldNameUpdatedHandler.scala
@@ -1,0 +1,18 @@
+package com.socrata.pg.store.events
+
+import com.socrata.pg.store.{PGSecondaryLogger, PGSecondaryUniverse}
+import com.socrata.soql.types.{SoQLValue, SoQLType}
+import com.socrata.datacoordinator.secondary.{ColumnInfo => SecondaryColumnInfo}
+import com.socrata.datacoordinator.truth.metadata.{CopyInfo => TruthCopyInfo, DatasetCopyContext}
+
+case class FieldNameUpdatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
+                                             truthCopyInfo: TruthCopyInfo,
+                                             secColInfo: SecondaryColumnInfo[SoQLType]) {
+  val sLoader = pgu.schemaLoader(new PGSecondaryLogger[SoQLType, SoQLValue])
+
+  val truthCopyContext = new DatasetCopyContext[SoQLType](truthCopyInfo, pgu.datasetMapReader.schema(truthCopyInfo))
+  val truthColInfo = truthCopyContext.thaw().columnInfo(secColInfo.systemId)
+
+  pgu.datasetMapWriter.updateFieldName(truthColInfo, secColInfo.fieldName.get) // can't update field name to None
+  sLoader.updateFieldName(truthColInfo)
+}

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
@@ -6,6 +6,7 @@ import com.socrata.datacoordinator.secondary.{DatasetInfo => SecondaryDatasetInf
 import com.socrata.datacoordinator.truth.metadata.{CopyInfo => TruthCopyInfo}
 import com.socrata.datacoordinator.truth.metadata.{DatasetInfo => TruthDatasetInfo}
 import com.socrata.pg.store.PGSecondaryUtil._
+import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types._
 import com.socrata.thirdparty.typesafeconfig.Propertizer
 import org.apache.log4j.PropertyConfigurator
@@ -44,10 +45,10 @@ abstract class PGSecondaryTestBase extends FunSuite with Matchers with BeforeAnd
     val pgs = new PGSecondary(config)
     val events = Seq(
       WorkingCopyCreated(copyInfo),
-      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), SoQLVersion, false, false, true)),
-      ColumnCreated(ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), SoQLText, false, false, false)),
-      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, true, false, false))
+      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), Some(ColumnName("my_column")), SoQLText, false, false, false, None)),
+      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None))
     )
   }
 
@@ -56,14 +57,30 @@ abstract class PGSecondaryTestBase extends FunSuite with Matchers with BeforeAnd
     val dataVersion = 0L
     val copyInfo = SecondaryCopyInfo(new CopyId(-1), 1, LifecycleStage.Published, dataVersion, new DateTime())
     val pgs = new PGSecondary(config)
-    val testColInfo = ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), SoQLText, false, false, false)
+    val testColInfo = ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), Some(ColumnName("my_column")), SoQLText, false, false, false, None)
     val events = Seq(
       WorkingCopyCreated(copyInfo),
-      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), SoQLVersion, false, false, true)),
+      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None)),
       ColumnCreated(testColInfo),
       ColumnRemoved(testColInfo),
-      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, true, false, false))
+      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None))
+    )
+  }
+
+  def fieldNameUpdatedFixture = new { // scalastyle:ignore
+  val datasetInfo = DatasetInfo(testInternalName, localeName, obfuscationKey)
+    val dataVersion = 0L
+    val copyInfo = SecondaryCopyInfo(new CopyId(-1), 1, LifecycleStage.Published, dataVersion, new DateTime())
+    val pgs = new PGSecondary(config)
+    val testColInfo = ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), Some(ColumnName("my_column")), SoQLText, false, false, false, None)
+    val events = Seq(
+      WorkingCopyCreated(copyInfo),
+      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None)),
+      ColumnCreated(testColInfo),
+      FieldNameUpdated(testColInfo.copy(fieldName = Some(ColumnName("my_column_2")))),
+      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None))
     )
   }
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUniverseTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUniverseTest.scala
@@ -7,7 +7,7 @@ import com.socrata.datacoordinator.secondary
 import com.socrata.datacoordinator.truth.metadata._
 import com.socrata.datacoordinator.truth.universe.sql.SqlTableCleanup
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
-import com.socrata.soql.environment.TypeName
+import com.socrata.soql.environment.{ColumnName, TypeName}
 import com.socrata.soql.types._
 import org.postgresql.util.PSQLException
 import org.scalatest.exceptions.TestFailedException
@@ -45,7 +45,7 @@ class PGSecondaryUniverseTest extends FunSuite with Matchers with BeforeAndAfter
       val (pgu, copyInfo, sLoader) = createTable(conn:Connection)
 
       val cols = SoQLType.typesByName filterKeys (!UnsupportedTypes.contains(_)) map {
-        case (n, t) => pgu.datasetMapWriter.addColumn(copyInfo, new UserColumnId(n + "_USERNAME"), t, n + "_PHYSNAME")
+        case (n, t) => pgu.datasetMapWriter.addColumn(copyInfo, new UserColumnId(n + "_USERNAME"), Some(ColumnName(n + "_FIELD")), t, n + "_PHYSNAME", None)
       }
       sLoader.addColumns(cols)
 
@@ -61,7 +61,7 @@ class PGSecondaryUniverseTest extends FunSuite with Matchers with BeforeAndAfter
       val types = SoQLType.typesByName filterKeys (!UnsupportedTypes.contains(_))
 
       val cols = types map {
-        case (n, t) => pgu.datasetMapWriter.addColumn(copyInfo, new UserColumnId(n + "_USERNAME"), t, n + "_PHYSNAME")
+        case (n, t) => pgu.datasetMapWriter.addColumn(copyInfo, new UserColumnId(n + "_USERNAME"), Some(ColumnName(n + "_FIELD")), t, n + "_PHYSNAME", None)
       }
       sLoader.addColumns(cols)
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
@@ -1,12 +1,12 @@
 package com.socrata.pg.store
 
 import scala.language.reflectiveCalls
-import com.socrata.datacoordinator.secondary.{ColumnInfo, LifecycleStage, CopyInfo, DatasetInfo}
+import com.socrata.datacoordinator.secondary.LifecycleStage
 import com.socrata.datacoordinator.id.{UserColumnId, ColumnId, CopyId}
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
+import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types._
 import com.rojoma.simplearm.util._
-import com.rojoma.simplearm.SimpleArm
 import com.socrata.datacoordinator.secondary.ColumnInfo
 import com.socrata.datacoordinator.secondary.CopyInfo
 import com.socrata.datacoordinator.secondary.DatasetInfo
@@ -23,9 +23,9 @@ class ResyncTest extends PGSecondaryTestBase with PGStoreTestBase with PGSeconda
       val cookie = Option("monkey")
 
       val newSchema = ColumnIdMap[ColumnInfo[SoQLType]](
-        new ColumnId(10) -> ColumnInfo[SoQLType](new ColumnId(10), new UserColumnId(":id"), SoQLID, true, false, false),
-        new ColumnId(11) -> ColumnInfo[SoQLType](new ColumnId(11), new UserColumnId(":version"), SoQLVersion, false, false, true),
-        new ColumnId(12) -> ColumnInfo[SoQLType](new ColumnId(12), new UserColumnId("my column 11"), SoQLText, false, false, false)
+        new ColumnId(10) -> ColumnInfo[SoQLType](new ColumnId(10), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None),
+        new ColumnId(11) -> ColumnInfo[SoQLType](new ColumnId(11), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None),
+        new ColumnId(12) -> ColumnInfo[SoQLType](new ColumnId(12), new UserColumnId("my column 11"), Some(ColumnName("my_column_11")), SoQLText, false, false, false, None)
       )
 
       val rows = Seq(

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -8,6 +8,7 @@ import com.socrata.datacoordinator.truth.metadata.{CopyInfo => TruthCopyInfo, Li
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.pg.store.PGSecondaryUtil._
 import com.socrata.pg.store.events.{RollupCreatedOrUpdatedHandler, WorkingCopyCreatedHandler, WorkingCopyPublishedHandler}
+import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.types._
 import org.joda.time.DateTime
 
@@ -174,9 +175,9 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       val cookie = Option("monkey")
 
       val newSchema = ColumnIdMap[ColumnInfo[SoQLType]](
-        new ColumnId(10) -> ColumnInfo[SoQLType](new ColumnId(10), new UserColumnId(":id"), SoQLID, true, false, false),
-        new ColumnId(11) -> ColumnInfo[SoQLType](new ColumnId(11), new UserColumnId(":version"), SoQLVersion, false, false, true),
-        new ColumnId(12) -> ColumnInfo[SoQLType](new ColumnId(12), new UserColumnId("col"), SoQLText, false, false, false)
+        new ColumnId(10) -> ColumnInfo[SoQLType](new ColumnId(10), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None),
+        new ColumnId(11) -> ColumnInfo[SoQLType](new ColumnId(11), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None),
+        new ColumnId(12) -> ColumnInfo[SoQLType](new ColumnId(12), new UserColumnId("col"), Some(ColumnName("col")), SoQLText, false, false, false, None)
       )
 
       val rows = Seq(

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/FieldNameUpdatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/FieldNameUpdatedHandlerTest.scala
@@ -1,0 +1,34 @@
+package com.socrata.pg.store.events
+
+import com.socrata.datacoordinator.id.{ColumnId, UserColumnId}
+import com.socrata.datacoordinator.secondary.{FieldNameUpdated, ColumnCreated}
+import com.socrata.pg.store.{PGStoreTestBase, PGSecondaryUniverseTestBase, PGSecondaryTestBase}
+import com.socrata.soql.environment.ColumnName
+import scala.language.reflectiveCalls
+
+class FieldNameUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase with PGStoreTestBase {
+
+  test("Handle FieldNameUpdated") {
+    withPgu() { pgu =>
+      val f = fieldNameUpdatedFixture
+
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, f.events.iterator)
+
+      val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
+      val schema = pgu.datasetMapReader.schema(truthCopyInfo)
+
+
+      val expected = scala.collection.mutable.Map[UserColumnId, (ColumnId, Option[ColumnName])]()
+
+      f.events.foreach {
+        case ColumnCreated(ci) => expected.update(ci.id, (ci.systemId, ci.fieldName))
+        case FieldNameUpdated(ci) => expected.update(ci.id, (ci.systemId, ci.fieldName))
+        case _ =>
+      }
+
+      val expectedColumns = expected.map { p => (p._1, p._2._1, p._2._2) }
+
+      schema.values.map { ci => (ci.userColumnId, ci.systemId, ci.fieldName) } should contain theSameElementsAs expectedColumns
+    }
+  }
+}

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/SystemRowIdentifierChangedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/SystemRowIdentifierChangedHandlerTest.scala
@@ -1,5 +1,7 @@
 package com.socrata.pg.store.events
 
+import com.socrata.soql.environment.ColumnName
+
 import scala.language.reflectiveCalls
 
 import com.socrata.datacoordinator.id.{ColumnId, UserColumnId}
@@ -13,8 +15,8 @@ class SystemRowIdentifierChangedHandlerTest extends PGSecondaryTestBase with PGS
     withPgu() { pgu =>
       val f = workingCopyCreatedFixture
       val events = f.events ++ Seq(
-        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false))
+        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")),  SoQLID, false, false, false, None))
       )
       f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)
 
@@ -29,9 +31,9 @@ class SystemRowIdentifierChangedHandlerTest extends PGSecondaryTestBase with PGS
     withPgu() { pgu =>
       val f = workingCopyCreatedFixture
       val events = f.events ++ Seq(
-        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false))
+        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+        SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None))
       )
       intercept[UnsupportedOperationException] {
         f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/VersionColumnChangedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/VersionColumnChangedHandlerTest.scala
@@ -1,5 +1,7 @@
 package com.socrata.pg.store.events
 
+import com.socrata.soql.environment.ColumnName
+
 import scala.language.reflectiveCalls
 
 import com.socrata.datacoordinator.id.{ColumnId, UserColumnId}
@@ -13,8 +15,8 @@ class VersionColumnChangedHandlerTest extends PGSecondaryTestBase with PGSeconda
     withPgu() { pgu =>
       val f = workingCopyCreatedFixture
       val events = f.events ++ Seq(
-        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), SoQLID, false, false, false)),
-        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), SoQLID, false, false, false))
+        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLID, false, false, false, None)),
+        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLID, false, false, false, None))
       )
       f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)
 
@@ -29,9 +31,9 @@ class VersionColumnChangedHandlerTest extends PGSecondaryTestBase with PGSeconda
     withPgu() { pgu =>
       val f = workingCopyCreatedFixture
       val events = f.events ++ Seq(
-        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false)),
-        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), SoQLID, false, false, false))
+        ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":version")), SoQLID, false, false, false, None)),
+        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":version")), SoQLID, false, false, false, None)),
+        VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":version")), SoQLID, false, false, false, None))
       )
       intercept[UnsupportedOperationException] {
         f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)


### PR DESCRIPTION
Bumps to v.2.0.0 of data-coordinator.
 - BD migrations need to be run, but should otherwise be releasable
 - Need to write tests