### PR TITLE
EN-2137: Properly log cause of being unable to populate a rollup.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
@@ -117,10 +117,13 @@ class RollupManager(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: Cop
           createRollupTable(rollupReps, newTableName, rollupInfo)
           populateRollupTable(newTableName, rollupInfo, rollupAnalyses, rollupReps)
           createIndexes(newTableName, rollupInfo, rollupReps)
-        case e@(Failure(_: SoQLException) | Failure(_: StandaloneLexerException)) =>
-          logger.warn(s"Error updating $copyInfo, $rollupInfo, skipping building rollup", e)
         case Failure(e) =>
-          throw e
+          e match {
+            case e @ (_:SoQLException | _:StandaloneLexerException) =>
+              logger.warn(s"Error updating ${copyInfo}, ${rollupInfo}, skipping building rollup", e)
+            case _ =>
+              throw e
+          }
       }
 
       // drop the old rollup regardless so it doesn't leak, because we have no way to use or track old rollups at


### PR DESCRIPTION
Typically these are parsing errors if the schema has changed and the rollup hasn't been updated, eg.
delta importer drops and re-adds columns on schema changes and they get different internal ids.

This is a partial revert of 6c433194 which introduced this bug in a code review style change.  The issue
was it resulted in e not being typed as a Throwable, so it instead was calling an overloaded
warn(message : scala.Predef.String, params : scala.AnyRef*) method which then effectively ignored the
params argument.