### PR TITLE
EN-3281 - Consider discarded copies when determining dataVersion delta between truth and PG secondary

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -246,6 +246,11 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
 
     // If there's more than one version's difference between the last known copy in truth
     // and the last known copy in the secondary, force a resync.
+    // TODO : It seems weird to resync just because there's a version gap,
+    // but the PG secondary code has always worked this way, and we've never
+    // verified that playing back multiple versions in one go actually works in
+    // every case. At some point, we should take the time to verify this and
+    // revisit whether we actually want this resync logic to exist.
     val allCopiesInOrder = pgu.datasetMapReader.allCopies(truthDatasetInfo)
     val dvExpect = allCopiesInOrder.last.dataVersion + 1
     if (newDataVersion != dvExpect) {

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -244,7 +244,10 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     val truthDatasetInfo = pgu.datasetMapReader.datasetInfo(dsId).get
     val truthCopyInfo = pgu.datasetMapReader.latest(truthDatasetInfo)
 
-    val dvExpect = truthCopyInfo.dataVersion + 1
+    // If there's more than one version's difference between the last known copy in truth
+    // and the last known copy in the secondary, force a resync.
+    val allCopiesInOrder = pgu.datasetMapReader.allCopies(truthDatasetInfo)
+    val dvExpect = allCopiesInOrder.last.dataVersion + 1
     if (newDataVersion != dvExpect) {
       throw new ResyncSecondaryException(
         s"Current version ${truthCopyInfo.dataVersion}, next version ${newDataVersion} but should be ${dvExpect}")


### PR DESCRIPTION
See https://socrata.atlassian.net/browse/EN-3281

We are currently triggering unnecessary resyncs on the version event immediately following the dropping of a working copy. This is because we are using `PostgresDatasetMapReader.latest` to determine the list of copies that have been replicated to the secondary, and this method excludes discarded working copies whose dropCopy event has in fact been synced to the secondary. This commit makes sure that we consider those discarded copies when deciding whether to resync.