### PR TITLE
EN-4323: Implement Secondary.dropCopy(.)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.9"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "2.1.11"
+    val dataCoordinator = "2.1.13"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"

--- a/store-pg/docker/Dockerfile
+++ b/store-pg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.11_5560_e90b78ba
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.13_5918_7c86a006
 
 # TODO expose JMX
 # EXPOSE

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -129,8 +129,11 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
   def dropCopy(datasetInfo: DatasetInfo,
                secondaryCopyInfo: SecondaryCopyInfo,
                cookie: Secondary.Cookie, isLatestCopy: Boolean): Secondary.Cookie = {
-    withPgu(dsInfo, None) { pgu =>
+    logger.info("droping copy (datasetInfo: {}, secondaryCopyInfo: {}, cookie: {})",
+      datasetInfo, secondaryCopyInfo, cookie)
+    withPgu(dsInfo, Some(datasetInfo)) { pgu =>
       doDropCopy(pgu, datasetInfo, secondaryCopyInfo, isLatestCopy)
+      pgu.commit()
     }
     cookie
   }

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -146,10 +146,11 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     val truthCopyInfo = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName) match {
       case None =>
         // Don't bother dropping a copy
-        if (isLatestCopy)
+        if (isLatestCopy) {
           // Well this is weird, but only going to log for now...
           logger.error("No dataset found for {} when dropping the latest copy {} for data version {}?",
             datasetInfo.internalName, secondaryCopyInfo.copyNumber.toString, secondaryCopyInfo.dataVersion.toString)
+        }
       case Some(dsId) =>
         pgu.datasetMapReader.datasetInfo(dsId).map { truthDatasetInfo =>
           pgu.datasetMapWriter.copyNumber(truthDatasetInfo, secondaryCopyInfo.copyNumber) match {
@@ -163,11 +164,12 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
               val rm = new RollupManager(pgu, copyInfo)
               rm.dropRollups(immediate = true) // drop all rollup tables
               pgu.secondaryDatasetMapWriter.deleteCopy(copyInfo)
-              if (isLatestCopy)
+              if (isLatestCopy) {
                 // create the `copy_map` entry
                 pgu.datasetMapWriter.unsafeCreateCopy(truthDatasetInfo, copyInfo.systemId, copyInfo.copyNumber,
                   TruthLifecycleStage.valueOf(secondaryCopyInfo.lifecycleStage.toString),
                   secondaryCopyInfo.dataVersion)
+              }
             case None =>
               // no copy to drop
               if (isLatestCopy) {

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -143,7 +143,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     // If this is the case, resync(.) will have already been called on a (un)published
     // copy and appropriate metadata should exist for this dataset.
     // Otherwise, we want to drop this copy entirely.
-    val truthCopyInfo = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName) match {
+    pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName) match {
       case None =>
         // Don't bother dropping a copy
         if (isLatestCopy) {
@@ -158,7 +158,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
               // drop the copy
               logger.info(
                 "dropping copy {} {}",
-                truthDatasetInfo.systemId.toString(),
+                truthDatasetInfo.systemId.toString,
                 secondaryCopyInfo.copyNumber.toString
               )
               val rm = new RollupManager(pgu, copyInfo)
@@ -506,7 +506,6 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     }
     pgu.datasetMapWriter.updateLastModified(truthCopyInfo, secondaryCopyInfo.lastModified)
 
-    // TODO: this seems like potentially wrong the wrong version?
     val postUpdateTruthCopyInfo = pgu.datasetMapReader.latest(truthCopyInfo.datasetInfo)
     // re-create rollup metadata
     for { rollup <- rollups } RollupCreatedOrUpdatedHandler(pgu, postUpdateTruthCopyInfo, rollup)

--- a/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
@@ -69,5 +69,101 @@ class ResyncTest extends PGSecondaryTestBase with PGStoreTestBase with PGSeconda
     }
   }
 
+  test("handle drop copy") {
+    withPgu() { pgu =>
+      val pgs = new PGSecondary(config)
+      val secondaryDatasetInfo = DatasetInfo("monkey", "locale", "obfuscate".getBytes)
+
+      val snapshottedCopy = CopyInfo(new CopyId(123), 1, LifecycleStage.Snapshotted, 24, new DateTime())
+      val publishedCopy = CopyInfo(new CopyId(123), 2, LifecycleStage.Published, 55, new DateTime())
+      val unpublishedCopy = CopyInfo(new CopyId(123), 3, LifecycleStage.Unpublished, 57, new DateTime())
+      val discardedCopy = CopyInfo(new CopyId(123), 3, LifecycleStage.Discarded, 58, new DateTime())
+
+      val cookie = Option("monkey")
+
+      val newSchema = ColumnIdMap[ColumnInfo[SoQLType]](
+        new ColumnId(10) -> ColumnInfo[SoQLType](new ColumnId(10), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None),
+        new ColumnId(11) -> ColumnInfo[SoQLType](new ColumnId(11), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None),
+        new ColumnId(12) -> ColumnInfo[SoQLType](new ColumnId(12), new UserColumnId("my column 11"), Some(ColumnName("my_column_11")), SoQLText, false, false, false, None)
+      )
+
+      val rows = Seq(
+        ColumnIdMap[SoQLValue](
+          new ColumnId(10) -> new SoQLID(10),
+          new ColumnId(11) -> new SoQLVersion(20),
+          new ColumnId(12) -> new SoQLText("foo")),
+        ColumnIdMap[SoQLValue](
+          new ColumnId(10) -> new SoQLID(11),
+          new ColumnId(11) -> new SoQLVersion(20),
+          new ColumnId(12) -> new SoQLText("bar"))
+      )
+
+      val rows2 = rows :+
+        ColumnIdMap[SoQLValue](
+          new ColumnId(10) -> new SoQLID(12),
+          new ColumnId(11) -> new SoQLVersion(20),
+          new ColumnId(12) -> new SoQLText("taz"))
+
+      // resync with the unpublished copy
+      pgs.doDropCopy(pgu, secondaryDatasetInfo, snapshottedCopy, isLatestCopy = false)
+      pgs.doResync(pgu, secondaryDatasetInfo, publishedCopy, newSchema, cookie, unmanaged(rows.iterator), Seq.empty)
+      pgs.doResync(pgu, secondaryDatasetInfo, unpublishedCopy, newSchema, cookie, unmanaged(rows2.iterator), Seq.empty)
+
+      // unpublished copy should be the "latest"
+      for {
+        unpublished <- unmanaged(getTruthCopyInfo(pgu, secondaryDatasetInfo))
+      } unpublished.copyNumber shouldEqual 3
+
+      for {
+        copies <- unmanaged(getTruthCopies(pgu, secondaryDatasetInfo))
+      } {
+        val copiesArray = copies.toArray
+
+        // published copy
+        val published = copiesArray(0)
+        published.copyNumber shouldEqual 1 // Note: this is 1 instead of 2 because how resync works on a uncreated dataset
+        published.dataVersion shouldEqual 55
+        for {
+          reader <- pgu.datasetReader.openDataset(published)
+          rows <- reader.rows()
+        } rows.size shouldEqual 2
+
+        // unpublished copy
+        val unpublished = copiesArray(1)
+        unpublished.copyNumber shouldEqual 3
+        unpublished.dataVersion shouldEqual 57
+      }
+
+      // now lets go through the resync process again, but this time the latest copy is discarded
+      pgs.doDropCopy(pgu, secondaryDatasetInfo, snapshottedCopy, isLatestCopy = false)
+      pgs.doResync(pgu, secondaryDatasetInfo, publishedCopy, newSchema, cookie, unmanaged(rows.iterator), Seq.empty)
+      pgs.doDropCopy(pgu, secondaryDatasetInfo, discardedCopy, isLatestCopy = true)
+
+      // "latest" copy should be the published one
+      for {
+        published <- unmanaged(getTruthCopyInfo(pgu, secondaryDatasetInfo))
+      } published.copyNumber shouldEqual 2
+
+      for {
+        copies <- unmanaged(getTruthCopies(pgu, secondaryDatasetInfo))
+      } {
+        val copiesArray = copies.toArray
+
+        // published copy
+        val published = copiesArray(0)
+        published.copyNumber shouldEqual 2
+        published.dataVersion shouldEqual 55
+        for {
+          reader <- pgu.datasetReader.openDataset(published)
+          rows <- reader.rows()
+        } rows.size shouldEqual 2
+
+        // discarded copy
+        val discarded = copiesArray(1)
+        discarded.copyNumber shouldEqual 3
+        discarded.dataVersion shouldEqual 58
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
Secondary.dropCopy(.) is part of the resync
path for discarded and snappshotted copies.
Keep an entry in `copy_map` for a discarded
copy during resync only if it is the latest
copy of the dataset.

We want to do this because secondary-watcher
updates the secondary manifest to say that
a secondary is done with the _latest_ copy
of a dataset after resync.