### PR TITLE
When I try to bump DC to v2.1.14-SNAPSHOT, a test suddenly fails.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
@@ -290,5 +290,5 @@ object RollupManager {
   def makeSecondaryRollupInfo(rollupInfo: RollupInfo): SecondaryRollupInfo =
      SecondaryRollupInfo(rollupInfo.name.underlying, rollupInfo.soql)
 
-  def shouldMaterializeRollups(stage: LifecycleStage): Boolean = stage != LifecycleStage.Unpublished
+  def shouldMaterializeRollups(stage: LifecycleStage): Boolean = stage == LifecycleStage.Published
 }


### PR DESCRIPTION
It was succeeding only because a map is traversed at a specific order and return the "right" key columns from two conflicting columns.
This actually removes the duplicated key column.