### PR TITLE
EN-5261: Fix most-recent copy related bugs.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.9"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "2.1.16"
+    val dataCoordinator = "2.1.18"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"

--- a/store-pg/docker/Dockerfile
+++ b/store-pg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.16_6085_6c69662f
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:2.1.18_6286_614dcf15
 
 # TODO expose JMX
 # EXPOSE

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -290,7 +290,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     // every case. At some point, we should take the time to verify this and
     // revisit whether we actually want this resync logic to exist.
     val allCopiesInOrder = pgu.datasetMapReader.allCopies(truthDatasetInfo)
-    val dvExpect = allCopiesInOrder.last.dataVersion + 1
+    val dvExpect = allCopiesInOrder.maxBy(_.dataVersion).dataVersion + 1
     if (newDataVersion != dvExpect) {
       throw new ResyncSecondaryException(
         s"Current version ${truthCopyInfo.dataVersion}, next version ${newDataVersion} but should be ${dvExpect}")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.10-SNAPSHOT"
+version in ThisBuild := "2.0.10"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.0.10"
+version in ThisBuild := "2.0.11-SNAPSHOT"


### PR DESCRIPTION
Fix false assumptions around:
* most-recently-created copy is the most-recent copy

Pickup secondary-watcher changes