### PR TITLE
When pg secondary is in a state where newer copies exist but is asked…

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -251,8 +251,9 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
       e match {
         case WorkingCopyCreated(copyInfo) =>
           val theCopy = existingDataset.flatMap { dsInfo =>
-              val allCopies = pgu.datasetMapReader.allCopies(dsInfo)
-              allCopies.find(existingCopyInfo => existingCopyInfo.copyNumber == copyInfo.copyNumber)
+            val allCopies = pgu.datasetMapReader.allCopies(dsInfo)
+            // Either this copy or some newer copy
+            allCopies.find(existingCopyInfo => existingCopyInfo.copyNumber >= copyInfo.copyNumber)
           }
           if (theCopy.isDefined) {
             logger.info("dataset {} working copy {} already existed, resync",


### PR DESCRIPTION
… by SW to play version of some older copy, it will fail (but won't kill SW).

This helps get out of the corrupted situation by kicking off resync.