### PR TITLE
EN-5915: Use Java8 base image for dockerizing soql-server-pg

### DIFF
--- a/soql-server-pg/docker/Dockerfile
+++ b/soql-server-pg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/java
+FROM socrata/java8
 
 # TODO expose JMX
 EXPOSE 6090 6091


### PR DESCRIPTION
Jenkins jobs are updated to build the code with Java 8. Build passed in Jenkins and container is running fine in staging under Java 8.