### PR TITLE
EN-5912: Use Java8 base image for secondary-watcher-pg

### DIFF
--- a/store-pg/docker/Dockerfile
+++ b/store-pg/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.5_6506_8bc696db
+FROM registry.docker.aws-us-west-2-infrastructure.socrata.net:5000/internal/secondary-watcher:3.0.6_6655_ad17e694
 
 # TODO expose JMX
 # EXPOSE


### PR DESCRIPTION
Looks good so far in Jenkins and staging. Will monitor in staging for a bit before merging.