### PR TITLE
Add logging around various parts of the log playback

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -13,7 +13,8 @@ object BuildSettings {
 
   val projectSettings = buildSettings ++
     Seq(
-      // TODO: enable code coverage build failures
+      com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Test := {},
+      com.socrata.sbtplugins.StylePlugin.StyleKeys.styleCheck in Compile := {},
       scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageFailOnMinimum := false
     )
 }


### PR DESCRIPTION
..when a table-copy happens because of a large upsert.

The cause of the table copy and times for its creation and re-indexing
and re-rolling-up are logged.