### PR TITLE
EN-5371: Skip null sub column

### DIFF
--- a/soql-server-pg/src/test/resources/fixtures/select-location-address-only.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-location-address-only.json
@@ -1,2 +1,4 @@
-[{"code":"LOCATION_ADDRESS","location": { "human_address": "{\"address\":\"101 Main St\", \"city\": \"Seattle\", \"state\": \"WA\", \"zip\": \"98104\"}"}}
+[ {"code":"LOCATION",
+   "location":{ "latitude": 1.1, "longitude": 2.2, "human_address": "{\"address\":\"101 Main St\", \"city\": \"Seattle\", \"state\": \"WA\", \"zip\": \"98104\"}"}},
+  {"code":"LOCATION_ADDRESS","location": { "human_address": "{\"address\":\"101 Main St\", \"city\": \"Seattle\", \"state\": \"WA\", \"zip\": \"98104\"}"}}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/select-location-lat-lng-only.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-location-lat-lng-only.json
@@ -1,2 +1,4 @@
-[{"code":"LOCATION_LATLNG","location": { "latitude": 1.1, "longitude": 2.2 }}
+[ {"code":"LOCATION",
+   "location":{ "latitude": 1.1, "longitude": 2.2, "human_address": "{\"address\":\"101 Main St\", \"city\": \"Seattle\", \"state\": \"WA\", \"zip\": \"98104\"}"}},
+  {"code":"LOCATION_LATLNG","location": { "latitude": 1.1, "longitude": 2.2 }}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/select-phone-number.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-phone-number.json
@@ -1,2 +1,3 @@
-[{"code":"LOCATION_ADDRESS","phone": { "phone_number": "4251234567" }}
+[ {"code":"LOCATION", "phone": { "phone_number": "4251234567", "phone_type": "Home" }},
+  {"code":"LOCATION_ADDRESS","phone": { "phone_number": "4251234567" }}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/select-phone-type.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-phone-type.json
@@ -1,2 +1,3 @@
-[{"code":"LOCATION_LATLNG","phone": { "phone_type": "Home"}}
+[ {"code":"LOCATION", "phone": { "phone_number": "4251234567", "phone_type": "Home" }},
+  {"code":"LOCATION_LATLNG","phone": { "phone_type": "Home"}}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/select-url-description.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-url-description.json
@@ -1,2 +1,3 @@
-[{"code":"LOCATION_LATLNG","url": { "description": "Home Site"}}
+[ {"code":"LOCATION", "url": { "url": "http://www.socrata.com", "description": "Home Site" }},
+  {"code":"LOCATION_LATLNG","url": { "description": "Home Site"}}
 ]

--- a/soql-server-pg/src/test/resources/fixtures/select-url-url.json
+++ b/soql-server-pg/src/test/resources/fixtures/select-url-url.json
@@ -1,2 +1,3 @@
-[{"code":"LOCATION_ADDRESS","url": { "url": "http://www.socrata.com" }}
+[ {"code":"LOCATION", "url": { "url": "http://www.socrata.com", "description": "Home Site" }},
+  {"code":"LOCATION_ADDRESS","url": { "url": "http://www.socrata.com" }}
 ]


### PR DESCRIPTION
This is done to make it easy to work with obe
select * where phone = '4251234567' will only compare phone.number
select * where phone = 'Home: 4251234567' will compare both