### PR TITLE
Chained SoQL search needs to run in the context of the previous SoQL.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
@@ -17,15 +17,19 @@ trait FullTextSearch[CT] {
    */
   def searchVector(reps: Seq[SqlColumnCommonRep[CT]]): Option[String] = {
     val repsSearchableTypes = reps.filter(r => SearchableTypes.contains(r.representedType))
-    val phyCols = repsSearchableTypes.flatMap(rep => rep.physColumns.map(phyCol => s"coalesce($phyCol,'')"))
+    val phyCols = repsSearchableTypes.flatMap(rep => rep.physColumns.map(phyCol => coalesce(phyCol)))
     toTsVector(phyCols)
   }
 
   def searchVector(selection: OrderedMap[ColumnName, CoreExpr[_, CT]]): Option[String] = {
     val cols = selection.view.filter(x => SearchableTypes.contains(x._2.typ)).map { case (columnName, expr) =>
-      columnName.name
+      coalesce(columnName.name)
     }
     toTsVector(cols.toSeq)
+  }
+
+  private def coalesce(col: String): String = {
+    s"coalesce($col,'')"
   }
 
   private def toTsVector(cols: Seq[String]): Option[String] = {

--- a/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
@@ -1,6 +1,9 @@
 package com.socrata.pg.store.index
 
 import com.socrata.datacoordinator.truth.sql.SqlColumnCommonRep
+import com.socrata.soql.collection.OrderedMap
+import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.typed.CoreExpr
 import com.socrata.soql.types.{SoQLArray, SoQLObject, SoQLText, SoQLType}
 
 trait FullTextSearch[CT] {
@@ -15,6 +18,18 @@ trait FullTextSearch[CT] {
   def searchVector(reps: Seq[SqlColumnCommonRep[CT]]): Option[String] = {
     val repsSearchableTypes = reps.filter(r => SearchableTypes.contains(r.representedType))
     val phyCols = repsSearchableTypes.flatMap(rep => rep.physColumns.map(phyCol => s"coalesce($phyCol,'')"))
-    if (phyCols.isEmpty) None else Some(phyCols.sorted.mkString("to_tsvector('english', ", " || ' ' || ", ")"))
+    toTsVector(phyCols)
+  }
+
+  def searchVector(selection: OrderedMap[ColumnName, CoreExpr[_, CT]]): Option[String] = {
+    val cols = selection.view.filter(x => SearchableTypes.contains(x._2.typ)).map { case (columnName, expr) =>
+      columnName.name
+    }
+    toTsVector(cols.toSeq)
+  }
+
+  private def toTsVector(cols: Seq[String]): Option[String] = {
+    if (cols.isEmpty) None
+    else Some(cols.sorted.mkString("to_tsvector('english', ", " || ' ' || ", ")"))
   }
 }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -314,7 +314,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("chained search scope is limited to the previous result") {
     val soql = "select case_number, primary_type search 'oNe' |> select * search 'tWo'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT \"case_number\",\"primary_type\" FROM (SELECT case_number as \"case_number\",primary_type as \"primary_type\" FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery('english', ?)) AS x1 WHERE to_tsvector('english', case_number || ' ' || primary_type) @@ plainto_tsquery('english', ?)")
+    sql should be ("SELECT \"case_number\",\"primary_type\" FROM (SELECT case_number as \"case_number\",primary_type as \"primary_type\" FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery('english', ?)) AS x1 WHERE to_tsvector('english', coalesce(case_number,'') || ' ' || coalesce(primary_type,'')) @@ plainto_tsquery('english', ?)")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq("oNe", "tWo"))
   }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -310,4 +310,20 @@ class SqlizerBasicTest extends SqlizerTest {
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(2, 3, 4, 1).map(BigDecimal(_)))
   }
+
+  test("chained search scope is limited to the previous result") {
+    val soql = "select case_number, primary_type search 'oNe' |> select * search 'tWo'"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT \"case_number\",\"primary_type\" FROM (SELECT case_number as \"case_number\",primary_type as \"primary_type\" FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery('english', ?)) AS x1 WHERE to_tsvector('english', case_number || ' ' || primary_type) @@ plainto_tsquery('english', ?)")
+    val params = setParams.map { (setParam) => setParam(None, 0).get }
+    params should be(Seq("oNe", "tWo"))
+  }
+
+  test("chained search scope is limited to the previous result and no searchable types is converted to false") {
+    val soql = "select id search 'oNe' |> select * search 'tWo'"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT \"id\" FROM (SELECT id as \"id\" FROM t1 WHERE to_tsvector('english', coalesce(array_12,'') || ' ' || coalesce(case_number_6,'') || ' ' || coalesce(object_11,'') || ' ' || coalesce(primary_type_7,'')) @@ plainto_tsquery('english', ?)) AS x1 WHERE false")
+    val params = setParams.map { (setParam) => setParam(None, 0).get }
+    params should be(Seq("oNe"))
+  }
 }


### PR DESCRIPTION
When no columns are searchable, return false instead of not having a condition.