### PR TITLE
Acquiring locks timeouts in 30s for migration.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/Migration.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/Migration.scala
@@ -22,8 +22,9 @@ object Migration {
                 operation: MigrationOperation = MigrationOperation.Migrate,
                 changeLogPath: String = MigrationScriptPath): Unit = {
 
+    val jdbc = new NonCommmittingJdbcConnenction(conn)
     LogFactory.getLogger().setLogLevel("warning")
-    val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, new JdbcConnection(conn))
+    val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, jdbc)
     val database = conn.getCatalog
 
     operation match {
@@ -31,6 +32,7 @@ object Migration {
       case Undo => liquibase.rollback(1, database)
       case Redo => { liquibase.rollback(1, database); liquibase.update(database) }
     }
+    jdbc.realCommit()
   }
 
   private val MigrationScriptPath = "com/socrata/pg/store/schema/migrate.xml"

--- a/common-pg/src/main/scala/com/socrata/pg/store/NonCommittingJdbcConnection.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/NonCommittingJdbcConnection.scala
@@ -1,0 +1,27 @@
+package com.socrata.pg.store
+
+
+import java.sql.Connection
+
+import liquibase.database.jvm.JdbcConnection
+
+/**
+  * liquibase always commits at the end of a changeSet.
+  * This class override commit and allows multi-changeSets migration to be commit or rollback
+  * as one transaction.
+  *
+  * liquibase always rollbacks after prerequisite check.  Therefore, rollback is also ignored.
+  *
+  * When this connection is used for liquibase migration, changeSet.runInTransaction must be true(which is the default).
+  * Because this connection is twisted, it should not be used for anything except liquibase migration.
+  */
+class NonCommmittingJdbcConnenction(conn: Connection) extends JdbcConnection(conn) {
+
+  conn.setAutoCommit(false)
+
+  override def commit(): Unit = { }
+
+  override def rollback(): Unit = { }
+
+  def realCommit(): Unit = conn.commit()
+}

--- a/store-pg/src/main/scala/com/socrata/pg/store/SchemaMigrator.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/SchemaMigrator.scala
@@ -13,7 +13,9 @@ object SchemaMigrator {
     for {
       dataSourceInfo <- DataSourceFromConfig(new DataSourceConfig(config, databaseTree))
       conn <- managed(dataSourceInfo.dataSource.getConnection)
+      stmt <- managed(conn.createStatement())
     } {
+      stmt.execute("SET lock_timeout = '30s'")
       Migration.migrateDb(conn, operation)
     }
   }


### PR DESCRIPTION
Run migration in one transaction.