### PR TITLE
En 7531 - runtime-configurable thresholds for table-copying

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/config/StoreConfig.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/config/StoreConfig.scala
@@ -1,5 +1,6 @@
 package com.socrata.pg.config
 
+import com.socrata.curator.CuratorConfig
 import com.typesafe.config.{ConfigUtil, Config}
 import com.socrata.thirdparty.typesafeconfig.ConfigClass
 import com.socrata.datacoordinator.common.DataSourceConfig
@@ -19,4 +20,8 @@ class StoreConfig(config: Config, root: String) extends ConfigClass(config, root
   val tablespace = optionally(getString("tablespace"))
 
   val resyncBatchSize = optionally(getInt("resyncBatchSize")).getOrElse(defaultResyncBatchSize)
+
+  val curatorConfig = optionally(getRawConfig("curator")).map { _ =>
+    getConfig("curator", new CuratorConfig(_, _))
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
     val metricsJetty = "3.1.0"
     val metricsGraphite = "3.0.2"
     val metricsScala = "3.3.0"
+    val clojure = "1.5.1"
   }
 
   val c3p0 = "com.mchange" % "c3p0" % versions.c3p0
@@ -75,4 +76,6 @@ object Dependencies {
   val metricsGraphite = "com.codahale.metrics" % "metrics-graphite" % versions.metricsGraphite exclude(
                            "com.codahale.metrics", "metrics-core")
   val metricsScala = "nl.grons" %% "metrics-scala" % versions.metricsScala
+
+  val clojure = "org.clojure" % "clojure" % versions.clojure
 }

--- a/project/StorePG.scala
+++ b/project/StorePG.scala
@@ -8,7 +8,8 @@ object StorePG {
   )
 
   def libraries(implicit scalaVersion: String) = Seq(
-    secondarylib
+    secondarylib,
+    clojure
   )
 }
 

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -3,6 +3,7 @@ package com.socrata.pg.store
 import java.io.Closeable
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
+import com.socrata.curator.CuratorFromConfig
 import com.socrata.pg.BuildInfo
 import com.mchange.v2.c3p0.DataSources
 import com.rojoma.simplearm.Managed
@@ -37,7 +38,13 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
   private val tableDropper = startTableDropper()
   private val resyncBatchSize = storeConfig.resyncBatchSize
   private val tableDropTimeoutSeconds: Long = 60
-  private val  rowsChangedPreviewHandler = new RowsChangedPreviewHandler(RowsChangedPreviewConfig.Default)
+  private val curator = storeConfig.curatorConfig.map { cc =>
+    CuratorFromConfig.unmanaged(cc)
+  }
+
+  val rowsChangedPreviewConfig =
+    curator.fold[RowsChangedPreviewConfig](RowsChangedPreviewConfig.Default)(new RowsChangedPreviewConfig.ZKClojure(_, "/soql-postgres-secondary"))
+  private val rowsChangedPreviewHandler = new RowsChangedPreviewHandler(rowsChangedPreviewConfig)
 
   val postgresUniverseCommon = new PostgresUniverseCommon(TablespaceFunction(storeConfig.tablespace), dsInfo.copyIn)
 
@@ -47,6 +54,11 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
     finished.countDown()
     tableDropper.join()
     dsInfo.close()
+    rowsChangedPreviewConfig match {
+      case closable: Closeable => closable.close()
+      case _ => // ok
+    }
+    curator.foreach(_.close())
     logger.info("shut down {} {}", dsConfig.host, dsConfig.database)
   }
 

--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -37,6 +37,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
   private val tableDropper = startTableDropper()
   private val resyncBatchSize = storeConfig.resyncBatchSize
   private val tableDropTimeoutSeconds: Long = 60
+  private val  rowsChangedPreviewHandler = new RowsChangedPreviewHandler(RowsChangedPreviewConfig.Default)
 
   val postgresUniverseCommon = new PostgresUniverseCommon(TablespaceFunction(storeConfig.tablespace), dsInfo.copyIn)
 
@@ -363,7 +364,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
           RollupDroppedHandler(pgu, truthCopyInfo, rollupInfo)
           (rebuildIndex, true, truthCopyInfo, dataLoader)
         case RowsChangedPreview(inserted, updated, deleted, truncated) =>
-          RowsChangedPreviewHandler(pgu, truthDatasetInfo, truthCopyInfo, truncated, inserted, updated, deleted) match {
+          rowsChangedPreviewHandler(pgu, truthDatasetInfo, truthCopyInfo, truncated, inserted, updated, deleted) match {
             case Some(nci) =>
               val isPublished = nci.lifecycleStage == TruthLifecycleStage.Published
               (isPublished, isPublished, nci, None)

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/RowsChangedPreviewConfig.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/RowsChangedPreviewConfig.scala
@@ -1,0 +1,13 @@
+package com.socrata.pg.store.events
+
+trait RowsChangedPreviewConfig {
+  def minRows(columnCount: Int): Long
+  def fractionOf(columnCount: Int): Double
+}
+
+object RowsChangedPreviewConfig {
+  object Default extends RowsChangedPreviewConfig {
+    override def minRows(columnCount: Int): Long = 100000
+    override def fractionOf(columnCount: Int): Double = 0.33333
+  }
+}

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/RowsChangedPreviewConfig.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/RowsChangedPreviewConfig.scala
@@ -1,13 +1,95 @@
 package com.socrata.pg.store.events
 
+import java.io.Closeable
+import java.nio.charset.StandardCharsets
+
+import com.rojoma.simplearm.v2.ResourceScope
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.recipes.cache.{NodeCacheListener, NodeCache}
+
 trait RowsChangedPreviewConfig {
   def minRows(columnCount: Int): Long
   def fractionOf(columnCount: Int): Double
 }
 
 object RowsChangedPreviewConfig {
-  object Default extends RowsChangedPreviewConfig {
-    override def minRows(columnCount: Int): Long = 100000
-    override def fractionOf(columnCount: Int): Double = 0.33333
+  class Clojure(val minRowsSource: String, val fractionOfSource: String) extends RowsChangedPreviewConfig {
+    clojure.lang.RT.T.hashCode(); // force RT to be initialized
+    val minRowsFunc = clojure.lang.Compiler.load(new java.io.StringReader(minRowsSource)).asInstanceOf[clojure.lang.IFn]
+    val fractionOfFunc = clojure.lang.Compiler.load(new java.io.StringReader(fractionOfSource)).asInstanceOf[clojure.lang.IFn]
+
+    override def minRows(columnCount: Int): Long =
+      minRowsFunc.invoke(columnCount).asInstanceOf[java.lang.Number].longValue()
+
+    override def fractionOf(columnCount: Int): Double =
+      fractionOfFunc.invoke(columnCount).asInstanceOf[java.lang.Number].doubleValue()
+  }
+
+  object Default extends Clojure("(fn [cols] 100000)", "(fn [cols] 0.33333)")
+
+  class ZKClojure(curator: CuratorFramework, path: String) extends RowsChangedPreviewConfig with Closeable {
+    private val resourceScope = new ResourceScope
+    private val updateMutex = new Object
+    private val minRowsCache = resourceScope.open(new NodeCache(curator, path + "/min-rows-func"))
+    private val fractionOfCache = resourceScope.open(new NodeCache(curator, path + "/fraction-of-func"))
+
+    @volatile private var current: Clojure = Default
+
+    private val minRowsListener = new NodeCacheListener {
+      override def nodeChanged(): Unit = {
+        minRowsCache.getCurrentData match {
+          case null =>
+            updateMutex.synchronized {
+              current = new Clojure(Default.minRowsSource, current.fractionOfSource)
+            }
+          case newSource =>
+            updateMutex.synchronized {
+              current = new Clojure(new String(newSource.getData, StandardCharsets.UTF_8), current.fractionOfSource)
+            }
+        }
+      }
+    }
+
+    private val fractionOfListener = new NodeCacheListener {
+      override def nodeChanged(): Unit = {
+        fractionOfCache.getCurrentData match {
+          case null =>
+            updateMutex.synchronized {
+              current = new Clojure(current.minRowsSource, Default.fractionOfSource)
+            }
+          case newSource =>
+            updateMutex.synchronized {
+              current = new Clojure(current.minRowsSource, new String(newSource.getData, StandardCharsets.UTF_8))
+            }
+        }
+      }
+    }
+
+    minRowsCache.getListenable.addListener(minRowsListener)
+    fractionOfCache.getListenable.addListener(fractionOfListener)
+
+    def close(): Unit = {
+      resourceScope.close()
+    }
+
+    def start(): Unit = {
+      minRowsCache.start(true)
+      try {
+        fractionOfCache.start(true)
+      } catch {
+        case t: Throwable =>
+          try {
+            resourceScope.close()
+          } catch {
+            case t2: Throwable =>
+              t.addSuppressed(t2)
+          }
+          throw t
+      }
+    }
+
+    override def minRows(columnCount: Int): Long = current.minRows(columnCount)
+
+    override def fractionOf(columnCount: Int): Double = current.fractionOf(columnCount)
   }
 }


### PR DESCRIPTION
Since we don't actually know what our thresholds should be for making an indexless copy on large upserts, this change allows us to store Clojure functions in Zookeeper and update them at runtime to configure the behavior based on number of columns.
