### PR TITLE
Have only one `main` in store-pg

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ be better to build the assembly and run it to save on memory:
 
 To run the migrations:
 ```sh
-sbt -Dconfig.file=/etc/soda2.conf "run-main com.socrata.pg.store.MigrateSchema migrate"
+sbt -Dconfig.file=/etc/soda2.conf "run-main com.socrata.pg.store.Main --migrate migrate"
 ```
 
 Alternatively, if you have an assembly jar you can use:

--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -13,4 +13,4 @@ if [ ! -e "$JARFILE" ]; then
     JARFILE=$(ls -t "${JARS[@]}" | head -n 1)
 fi
 ARGS=(Migrate)
-java -Dconfig.file="$CONFIG" -cp "$JARFILE" com.socrata.pg.store.MigrateSchema "${ARGS[@]}"
+java -Dconfig.file="$CONFIG" -cp "$JARFILE" com.socrata.pg.store.Main --migrate "${ARGS[@]}"

--- a/soql-server-pg/docker/ship.d/run
+++ b/soql-server-pg/docker/ship.d/run
@@ -6,7 +6,7 @@ set -ev
 su socrata -c '/usr/bin/java \
     -Dconfig.file=${SERVER_CONFIG} \
     -cp $SERVER_ARTIFACT \
-    com.socrata.pg.store.MigrateSchema Migrate \
+    com.socrata.pg.store.Main --migrate Migrate \
     com.socrata.soql-server-pg.migrations \
     '
 

--- a/store-pg/src/main/scala/com/socrata/pg/store/Main.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/Main.scala
@@ -3,5 +3,9 @@ package com.socrata.pg.store
 import com.socrata.datacoordinator.secondary.SecondaryWatcherApp
 
 object Main extends App {
-  SecondaryWatcherApp(new PGSecondary(_))
+  if(args.headOption == Some("--migrate")) {
+    MigrateSchema(args.drop(1))
+  } else {
+    SecondaryWatcherApp(new PGSecondary(_))
+  }
 }

--- a/store-pg/src/main/scala/com/socrata/pg/store/MigrateSchema.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/MigrateSchema.scala
@@ -9,13 +9,13 @@ import com.socrata.datacoordinator.truth.migration.Migration.MigrationOperation
 /**
  * This object takes Liquibase operations and performs according migrations to the pg-secondary schemas.
  */
-object MigrateSchema extends App {
+object MigrateSchema {
   /**
    * Performs a Liquibase schema migration.
    * @param args(0) Migration operation to perform.
    *        args(1) Optional dotted path reference the database config tree to migrate
    * */
-  override def main(args: Array[String]): Unit = {
+  def apply(args: Array[String]): Unit = {
     // Verify that two arguments were passed
     if (args.length < 1 || args.length > 2) {
       throw new IllegalArgumentException(


### PR DESCRIPTION
The migrations used to (and still do) live here too; that is no longer
a main class, and the docs and scripts have been updated to Do The Right
Thing to run them.