### PR TITLE
Warn about dropping nonexistant copies, rather than bailing

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.13"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.0.18"
+    val dataCoordinator = "3.0.51"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"

--- a/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
@@ -121,7 +121,7 @@ class ResyncTest extends PGSecondaryTestBase with PGStoreTestBase with PGSeconda
 
         // published copy
         val published = copiesArray(0)
-        published.copyNumber shouldEqual 1 // Note: this is 1 instead of 2 because how resync works on a uncreated dataset
+        published.copyNumber shouldEqual 2
         published.dataVersion shouldEqual 55
         for {
           reader <- pgu.datasetReader.openDataset(published)


### PR DESCRIPTION
This is probably fallout from the desecondarification of snapshots.