### PR TITLE
EN-4308: Use improved secondary-watcher version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.14"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.1.5"
+    val dataCoordinator = "3.3.0"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
Secondary-watcher now has:
 - retry logic around releasing claims
 - health check on updating claimed_at
 - in-memory working set to only update
   claimed_at time for datasets that
   the secondary is actually still working on