### PR TITLE
Reduce lock duration on some system tables during rows updates.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.14"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.3.0"
+    val dataCoordinator = "3.3.1"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"

--- a/soql-server-pg/src/test/scala/com/socrata/pg/store/SchemaTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/store/SchemaTest.scala
@@ -21,7 +21,7 @@ class SchemaTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBase 
       val f = columnsCreatedFixture
       f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, f.events.iterator)
       val qs = new QueryServerTest(dsInfo, pgu)
-      val schema = qs.getSchema(testInternalName, None).get
+      val schema = qs.getSchema(f.datasetInfo.internalName, None).get
       val schemaj = JsonUtil.renderJson(schema)
       val schemaRoundTrip = JsonUtil.parseJson[com.socrata.datacoordinator.truth.metadata.Schema](schemaj)
         .right.toOption.get

--- a/store-pg/src/test/scala/com/socrata/pg/store/CurrentCopyNumberTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/CurrentCopyNumberTest.scala
@@ -11,7 +11,7 @@ class CurrentCopyNumberTest extends PGSecondaryTestBase with PGSecondaryUniverse
 
       f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, f.events.iterator)
 
-      val actualCopyNum = f.pgs.doCurrentCopyNumber(pgu, testInternalName, None)
+      val actualCopyNum = f.pgs.doCurrentCopyNumber(pgu, f.datasetInfo.internalName, None)
 
       // right now we only support a single copy of the dataset ... so this is a silly test!
       actualCopyNum shouldEqual 1

--- a/store-pg/src/test/scala/com/socrata/pg/store/CurrentVersionTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/CurrentVersionTest.scala
@@ -16,7 +16,7 @@ class CurrentVersionTest extends PGSecondaryTestBase with PGSecondaryUniverseTes
         f.pgs.doVersion(pgu, f.datasetInfo, version, None, Iterator(e))
       }
 
-      f.pgs.doCurrentVersion(pgu, testInternalName, None) shouldEqual version
+      f.pgs.doCurrentVersion(pgu, f.datasetInfo.internalName, None) shouldEqual version
     }
   }
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUtil.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUtil.scala
@@ -1,7 +1,7 @@
 package com.socrata.pg.store
 
 object PGSecondaryUtil {
-  val testInternalName = "test-dataset"
+  def testInternalName: String = "test_dataset" + System.currentTimeMillis()
   val localeName = "us"
   val obfuscationKey = "key".getBytes
 }

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -117,7 +117,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       firstCopy.lifecycleStage should be (metadata.LifecycleStage.Unpublished)
       firstCopy.copyNumber should be (1L)
 
-      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(testInternalName)
+      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName)
       datasetId.isDefined should be (true)
       WorkingCopyPublishedHandler(pgu, firstCopy)
       val firstCopyPublished: TruthCopyInfo = getTruthCopyInfo(pgu, datasetInfo)
@@ -251,7 +251,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       firstCopy.lifecycleStage should be (metadata.LifecycleStage.Unpublished)
       firstCopy.copyNumber should be (1L)
 
-      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(testInternalName)
+      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName)
       datasetId.isDefined should be (true)
       WorkingCopyPublishedHandler(pgu, firstCopy)
       val firstCopyPublished: TruthCopyInfo = getTruthCopyInfo(pgu, datasetInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandlerTest.scala
@@ -42,7 +42,7 @@ class WorkingCopyCreatedHandlerTest extends PGSecondaryTestBase with PGSecondary
       firstCopy.lifecycleStage should be (metadata.LifecycleStage.Unpublished)
       firstCopy.copyNumber should be (1L)
 
-      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(testInternalName)
+      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName)
       datasetId.isDefined should be (true)
       WorkingCopyPublishedHandler(pgu, firstCopy)
       val firstCopyPublished = getTruthCopyInfo(pgu, datasetInfo)


### PR DESCRIPTION
This helps reduce lock problems in future db migrations.