### PR TITLE
EN-13224 Disable SoQL reads during resync.

### DIFF
--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUtil.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryUtil.scala
@@ -1,7 +1,11 @@
 package com.socrata.pg.store
 
+import java.util.concurrent.atomic.AtomicInteger
+
 object PGSecondaryUtil {
-  def testInternalName: String = "test_dataset" + System.currentTimeMillis()
+  private val counter = new AtomicInteger(0)
+
+  def testInternalName: String = "test_dataset" + counter.incrementAndGet()
   val localeName = "us"
   val obfuscationKey = "key".getBytes
 }

--- a/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/ResyncTest.scala
@@ -18,7 +18,7 @@ class ResyncTest extends PGSecondaryTestBase with PGStoreTestBase with PGSeconda
   test("handle resync") {
     withPgu() { pgu =>
       val pgs = new PGSecondary(config)
-      val secondaryDatasetInfo = DatasetInfo("monkey", "locale", "obfuscate".getBytes)
+      val secondaryDatasetInfo = DatasetInfo(PGSecondaryUtil.testInternalName, "locale", "obfuscate".getBytes)
       val secondaryCopyInfo = CopyInfo(new CopyId(123), 1, LifecycleStage.Published, 55, new DateTime())
       val cookie = Option("monkey")
 
@@ -72,7 +72,7 @@ class ResyncTest extends PGSecondaryTestBase with PGStoreTestBase with PGSeconda
   test("handle drop copy") {
     withPgu() { pgu =>
       val pgs = new PGSecondary(config)
-      val secondaryDatasetInfo = DatasetInfo("monkey", "locale", "obfuscate".getBytes)
+      val secondaryDatasetInfo = DatasetInfo(PGSecondaryUtil.testInternalName, "locale", "obfuscate".getBytes)
 
       val snapshottedCopy = CopyInfo(new CopyId(123), 1, LifecycleStage.Snapshotted, 24, new DateTime())
       val publishedCopy = CopyInfo(new CopyId(123), 2, LifecycleStage.Published, 55, new DateTime())

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -170,7 +170,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
   test("rollup survives resync") {
     withPgu() { pgu =>
       val pgs = new PGSecondary(config)
-      val secondaryDatasetInfo = DatasetInfo("monkey", "locale", "obfuscate".getBytes)
+      val secondaryDatasetInfo = DatasetInfo(PGSecondaryUtil.testInternalName, "locale", "obfuscate".getBytes)
       val secondaryCopyInfo = CopyInfo(new CopyId(123), 1, LifecycleStage.Published, 55, new DateTime())
       val cookie = Option("monkey")
 


### PR DESCRIPTION
Resync imposes lock conflict with reads which leads to backing up of connections.  That eventually takes down a pg query server.