### PR TITLE
Update readme to correct *.conf file for running migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ be better to build the assembly and run it to save on memory:
 
 To run the migrations:
 ```sh
-sbt -Dconfig.file=/etc/soda2.conf "run-main com.socrata.pg.store.Main --migrate migrate"
+sbt -Dconfig.file=/etc/pg-secondary.conf "run-main com.socrata.pg.store.Main --migrate migrate"
 ```
 
 Alternatively, if you have an assembly jar you can use:


### PR DESCRIPTION
Copying and pasting context here:

**Why?**
Because passing `soda2.conf` to this migration doesn't work. It throws this error: 
```bash
No configuration setting found for key 'com.socrata.pg'
```

**For context (from #hello-world slack channel)**

> Brian Tong: any advice on running the migration for soql-postgres-adapter? I’m getting a similar error from previous conversations in here about `No configuration setting found for key 'com.socrata.pg`', but I didn’t see any definitive solution in chat history

> Alexa Rüst: You might need both still?
You need a separate config file for the secondary-watcher-pg
So you probably want to use this https://github.com/socrata/docs/blob/master/onramp/services/pg-secondary.conf

corresponding update to install script here: https://github.com/socrata/docs/pull/130