### PR TITLE
EN-12729: Avoid deadlocks with new SW lib version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.0.14"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.3.4"
+    val dataCoordinator = "3.3.5"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
Avoid deadlocks when updating multiple rows on the
`secondary_manifest` by first obtaining locks on
the rows in a deterministic order, i.e. ordery by
`dataset_system_id` then `store_id`.