### PR TITLE
EN-13048 Use group by position if we find literal

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
@@ -128,6 +128,14 @@ object Sqlizer {
       ParametricSql(se, setParamsOrderBy)
     }
   }
+
+  def isLiteral(expr: CoreExpr[UserColumnId, SoQLType]): Boolean = {
+    expr match {
+      case cr: ColumnRef[UserColumnId, SoQLType] => false
+      case lit: TypedLiteral[SoQLType] => true
+      case fc: FunctionCall[UserColumnId, SoQLType] => fc.parameters.forall(x => isLiteral(x))
+    }
+  }
 }
 
 object SqlizerContext extends Enumeration {

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -326,4 +326,11 @@ class SqlizerBasicTest extends SqlizerTest {
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq("oNe"))
   }
+
+  test("group by literal") {
+    val soql = "select id, 'stRing' as a, 5 as b, 2*3 as c group by id, a, b, c"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT id,e'stRing',5,(2 * 3) FROM t1 GROUP BY id,2,3,4")
+    setParams.length should be (0)
+  }
 }


### PR DESCRIPTION
This fixes soql like
  SELECT ‘literal’ as x GROUP BY x