### PR TITLE
EN-14996 Add “Distinct” support

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -153,7 +153,8 @@ object SoQLAnalysisSqlizer extends Sqlizer[AnalysisTarget] {
     val setParamsOrderBy = orderBy.map(_._2).getOrElse(setParamsHaving)
 
     // COMPLETE SQL
-    val completeSql = selectPhrase.mkString("SELECT ", ",", "") +
+    val selectOptionalDistinct = "SELECT " + (if (analysis.distinct) "DISTINCT " else "")
+    val completeSql = selectPhrase.mkString(selectOptionalDistinct, ",", "") +
       s" FROM $tableName" +
       where.flatMap(_.sql.headOption.map(" WHERE " +  _)).getOrElse("") +
       search.flatMap(_.sql.headOption).getOrElse("") +

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -333,4 +333,12 @@ class SqlizerBasicTest extends SqlizerTest {
     sql should be ("SELECT id,e'stRing',5,(2 * 3) FROM t1 GROUP BY id,2,3,4")
     setParams.length should be (0)
   }
+
+  test("distinct") {
+    val soql = "select distinct case_number, primary_type"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT DISTINCT case_number,primary_type FROM t1")
+    setParams.length should be (0)
+  }
+
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.0.1"
     val socrataThirdPartyUtils = "4.0.1"
     val socrataHttpCuratorBroker = "3.3.0"
-    val soqlStdlib = "2.0.14"
+    val soqlStdlib = "2.1.0"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.3.5"
     val typesafeScalaLogging = "1.1.0"

--- a/soql-server-pg/src/test/resources/fixtures/distinct-group.json
+++ b/soql-server-pg/src/test/resources/fixtures/distinct-group.json
@@ -1,0 +1,10 @@
+[ { "make": "APCO", "count_name": 4 },
+  { "make": "ATHING", "count_name": 1 },
+  { "make": "FOXTROT", "count_name": 1 },
+  { "make": "GIN", "count_name": 2 },
+  { "make": "HOTEL", "count_name": 1 },
+  { "make": "OZONE", "count_name": 2 },
+  { "make": "Skywalk", "count_name": 3 },
+  { "make": "YANKEE", "count_name": 1 },
+  { "make": "zNA", "count_name": 3 }
+]

--- a/soql-server-pg/src/test/resources/fixtures/distinct.json
+++ b/soql-server-pg/src/test/resources/fixtures/distinct.json
@@ -1,0 +1,10 @@
+[ { "make": "APCO" },
+  { "make": "ATHING" },
+  { "make": "FOXTROT" },
+  { "make": "GIN" },
+  { "make": "HOTEL" },
+  { "make": "OZONE" },
+  { "make": "Skywalk" },
+  { "make": "YANKEE" },
+  { "make": "zNA" }
+]

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLDistinctTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLDistinctTest.scala
@@ -1,0 +1,11 @@
+package com.socrata.pg.server
+
+class SoQLDistinctTest extends SoQLTest {
+  test("distinct") {
+    compareSoqlResult("select distinct make order by make", "distinct.json")
+  }
+
+  test("distinct with grouping") {
+    compareSoqlResult("select distinct make, count(name) group by make order by make", "distinct-group.json")
+  }
+}


### PR DESCRIPTION
** DEPLOY soql-postgres-adapter BEFORE query-coordinator **
to avoid service interruption

Just the one in the select level.

SELECT DISTINCT col1, col2, …

not the one inside function

SELECT COUNT(DISTINCT col1)