### PR TITLE
EN-15144: Configurable com.socrata log level

### DIFF
--- a/store-pg/docker/secondary.conf.j2
+++ b/store-pg/docker/secondary.conf.j2
@@ -41,6 +41,10 @@ instances {
             }
           }
         }
+        # make it possible to optionally configure a higher log level for com.socrata components for debugging
+        {% if SOCRATA_LOG_LEVEL is defined -%}
+        logger.com.socrata = {{ SOCRATA_LOG_LEVEL }}
+        {%- endif %}
       }
 
       tablespace = "{{ PG_SECONDARY_TABLESPACE_FN }}"


### PR DESCRIPTION
Make it possible to optionally configure the
log level for com.socrata components to a higher
log level in docker for dugging Eurybates messages.