### PR TITLE
Bump DC version so that it usees camel case in messages instead of un…

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.1.1"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.3.9"
+    val dataCoordinator = "3.3.10"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
…derscore.

Historically, we use camel case for Eurybates messages.