### PR TITLE
EN-14749: Fix "data too long to index" errors for row updates.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/error/RowSizeBufferSqlErrorHandler.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/error/RowSizeBufferSqlErrorHandler.scala
@@ -1,10 +1,9 @@
 package com.socrata.pg.error
 
 import java.lang.reflect.InvocationTargetException
-import java.sql.Connection
+import java.sql.{BatchUpdateException, Connection}
 
 import scala.util.{Failure, Success, Try}
-
 import com.socrata.datacoordinator.secondary.ResyncSecondaryException
 import com.typesafe.scalalogging.slf4j.Logging
 import org.postgresql.util.PSQLException
@@ -48,8 +47,9 @@ object RowSizeBufferSqlErrorHandler extends Logging {
       f
     } catch {
       case ex: PSQLException => resyncIfIndexRowSizeError(ex)
-      case itex: InvocationTargetException => // sql exceptions wrapped in invocation target exception
-        itex.getCause match {
+       // sql exceptions wrapped in invocation target exception or from a batch update
+      case e @ (_ : InvocationTargetException | _ : BatchUpdateException) =>
+        e.getCause match {
           case ex: PSQLException => resyncIfIndexRowSizeError(ex)
           case ex: Throwable => throw ex
         }

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
@@ -52,6 +52,21 @@ abstract class PGSecondaryTestBase extends FunSuite with Matchers with BeforeAnd
     )
   }
 
+  def publishedDatasetFixture = new { // scalastyle:ignore
+    val datasetInfo = DatasetInfo(testInternalName, localeName, obfuscationKey, None)
+    val dataVersion = 0L
+    val copyInfo = SecondaryCopyInfo(new CopyId(-1), 1, LifecycleStage.Published, dataVersion, new DateTime())
+    val pgs = new PGSecondary(config)
+    val events = Seq(
+      WorkingCopyCreated(copyInfo),
+      ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9125), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLVersion, false, false, true, None)),
+      ColumnCreated(ColumnInfo(new ColumnId(9126), new UserColumnId("mycolumn"), Some(ColumnName("my_column")), SoQLText, false, false, false, None)),
+      SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, true, false, false, None)),
+      WorkingCopyPublished
+    )
+  }
+
   def columnsRemovedFixture = new { // scalastyle:ignore
     val datasetInfo = DatasetInfo(testInternalName, localeName, obfuscationKey, None)
     val dataVersion = 0L

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/RowDataUpdatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/RowDataUpdatedHandlerTest.scala
@@ -1,16 +1,21 @@
 package com.socrata.pg.store.events
 
 import scala.language.reflectiveCalls
-
 import com.rojoma.simplearm.util._
 import com.socrata.datacoordinator.id.{ColumnId, RowId}
-import com.socrata.datacoordinator.secondary.{Delete, Insert, RowDataUpdated, Update}
+import com.socrata.datacoordinator.secondary._
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.pg.store._
 import com.socrata.soql.types._
 import com.typesafe.scalalogging.slf4j.Logging
 
+import scala.util.Random
+
 class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase with PGStoreTestBase with Logging {
+
+  // We are generating a random string here to make it uncompressible, postgres can handle "simple"
+  // repeating strings of longer lengths.
+  private val longString = Random.alphanumeric.take(16*1024).mkString
 
   private val insertOps = Seq(
           (1000, 110, "foo"),
@@ -23,10 +28,21 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
           )
         }
 
+  private val insertOpsLongString = Seq(
+    (1000, 110, "foo"),
+    (1001, 112, "foo2"),
+    (1002, 114, longString)).map { r =>
+    Insert(new RowId(r._1), ColumnIdMap()
+      + ((new ColumnId(9124), new SoQLID(r._1)))
+      + ((new ColumnId(9125), new SoQLVersion(r._2)))
+      + ((new ColumnId(9126), new SoQLText(r._3)))
+    )
+  }
+
   test("handle row insert") {
     withPgu() {
       pgu =>
-        val f = columnsCreatedFixture
+        val f = publishedDatasetFixture
         val events = f.events ++ Seq(
           RowDataUpdated(insertOps)
         )
@@ -41,12 +57,27 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
     }
   }
 
+  test("handle row insert with long string") {
+    withPgu() {
+      pgu =>
+        val f = publishedDatasetFixture
+        val events = Seq(
+          RowDataUpdated(insertOpsLongString)
+        )
+
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, f.events.iterator)
+        intercept[ResyncSecondaryException] {
+          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, None, events.iterator)
+        }
+    }
+  }
+
   test("handle row update") {
     withDb() {
       conn =>
 
         val pgu = new PGSecondaryUniverse[SoQLType, SoQLValue](conn, PostgresUniverseCommon)
-        val f = columnsCreatedFixture
+        val f = publishedDatasetFixture
         val events = f.events :+ RowDataUpdated(insertOps)
 
         f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)
@@ -73,10 +104,38 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
     }
   }
 
+  test("handle row update with long string") {
+    withDb() {
+      conn =>
+
+        val pgu = new PGSecondaryUniverse[SoQLType, SoQLValue](conn, PostgresUniverseCommon)
+        val f = publishedDatasetFixture
+        val events = f.events :+ RowDataUpdated(insertOps)
+
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)
+
+        val updateOps = Seq(
+          (1000, 110, "bar"),
+          (1002, 114, longString)).map { r =>
+          Update(new RowId(r._1), ColumnIdMap()
+            + ((new ColumnId(9124), new SoQLID(r._1)))
+            + ((new ColumnId(9125), new SoQLVersion(r._2)))
+            + ((new ColumnId(9126), new SoQLText(r._3)))
+          )(None)
+        }
+
+        val updateEvents = Seq(RowDataUpdated(updateOps))
+
+        intercept[ResyncSecondaryException] {
+          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, None, updateEvents.iterator)
+        }
+    }
+  }
+
   test("handle row delete") {
     withDb() { conn =>
       val pgu = new PGSecondaryUniverse[SoQLType, SoQLValue](conn, PostgresUniverseCommon)
-      val f = columnsCreatedFixture
+      val f = publishedDatasetFixture
       val events = f.events :+ RowDataUpdated(insertOps)
 
       f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, None, events.iterator)


### PR DESCRIPTION
In commit 9b4871dbf8310bb5f9ccb7983b3a958afd6f729d, we previously added the functionality
to force a resync if a value is too large to index.  Going through resync, the value will be added,
the index creation will fail, and we will move on without an index on the column.

This wasn't working for updates because they are done as batch statements so you end up with a
BatchUpdateException.

Also, add some tests around these cases.  As part of that change the row update tests to use a published
dataset because unpublished datasets have fewer things (ie. indexes) on them.