### PR TITLE
EN-16800 Migration to create index on resource name (concurrently)

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20170615-add-dataset-map-resource-name-index.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20170615-add-dataset-map-resource-name-index.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="chi" id="20170615-add-dataset-map-resource-name-index" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(*) from pg_class where relname = 'dataset_map_resource_name'
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            CREATE INDEX CONCURRENTLY dataset_map_resource_name ON dataset_map(resource_name)
+        </sql>
+        <rollback>
+            <dropIndex indexName="dataset_map_resource_name" tableName="dataset_map"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -14,5 +14,6 @@
     <include file="com/socrata/pg/store/schema/20160420-add-copy-map-table-modifiers.xml"/>
     <include file="com/socrata/pg/store/schema/20161231-add-disabled.xml"/>
     <include file="com/socrata/pg/store/schema/20170402-add-column-resource-name.xml"/>
+    <include file="com/socrata/pg/store/schema/20170615-add-dataset-map-resource-name-index.xml"/>
 
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/store/Migration.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/Migration.scala
@@ -1,7 +1,7 @@
 package com.socrata.pg.store
 
 import liquibase.Liquibase
-import liquibase.database.jvm.JdbcConnection
+import liquibase.lockservice.LockService
 import liquibase.logging.LogFactory
 import liquibase.resource.ClassLoaderResourceAccessor
 
@@ -25,6 +25,8 @@ object Migration {
     val jdbc = new NonCommmittingJdbcConnenction(conn)
     LogFactory.getLogger().setLogLevel("warning")
     val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, jdbc)
+    val lockService = LockService.getInstance(liquibase.getDatabase)
+    lockService.setChangeLogLockWaitTime(1000 * 3) // 3s where value should be < SQL lock_timeout (30s)
     val database = conn.getCatalog
 
     operation match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.0.1"
     val socrataThirdPartyUtils = "4.0.1"
     val socrataHttpCuratorBroker = "3.3.0"
-    val soqlStdlib = "2.5.0"
+    val soqlStdlib = "2.5.1"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.3.13"
     val typesafeScalaLogging = "1.1.0"


### PR DESCRIPTION
setChangeLogLockWaitTime to a value smaller (3s) than sql lock_timeout (30s) so that migrations where runInTransaction="false" should go through fine.

Also bump soql-refernce just to get the latest version which is a refactor w/o semantic change.