### PR TITLE
EN-17014: SW PG can help move datasets

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.9.1"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.4.1"
+    val dataCoordinator = "3.4.6"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"


### PR DESCRIPTION
Secondary-watcher-pg can help move datasets between stores
to enable collocation. This does not have any locking and
must be manually triggered.