### PR TITLE
EN-17014: Bring in new DC version for SW

### DIFF
--- a/configs/soql-postgres-adapter.conf
+++ b/configs/soql-postgres-adapter.conf
@@ -2,8 +2,6 @@
 # Used for running the service locally as a process or in a docker container
 
 common-host = "local.dev.socrata.net"
-common-pg-host = ${common-host}
-common-soql-server-pg-host = ${common-host}
 common-pg-port = 5432
 common-qs-pg-port = 6050
 
@@ -13,7 +11,7 @@ common-zk-ensemble = ["local.dev.socrata.net:2181"]
 data-coordinator-instance = "primus"
 
 common-database {
-  host = ${common-pg-host}
+  host = ${common-host}
   port = ${common-pg-port}
   username = "blist"
   password = "blist"
@@ -96,7 +94,7 @@ com.socrata.soql-server-pg {
   port = ${common-qs-pg-port}
   curator = ${curator}
   instance = ${data-coordinator-instance}
-  service-advertisement.address = ${common-soql-server-pg-host}
+  service-advertisement.address = ${common-host}
 
   service-advertisement {
     base-path = "/services"
@@ -132,6 +130,22 @@ com.socrata.coordinator.secondary-watcher = ${com.socrata.coordinator.common} {
   database.app-name = "data coordinator secondary watcher"
   claim-timeout = 5m
   watcher-id = 61e9a209-98e7-4daa-9c43-5778a96e1d8a
+
+  curator =  ${curator}
+
+  service-advertisement.address = ${common-host}
+
+  service-advertisement {
+    service-base-path = "/services"
+    name = "data-coordinator"
+  }
+
+  // TODO: can these new things just be in the reference.conf in data-coordinator?
+  collocation {
+    lock-path = "collocation-lock"
+    lock-timeout = 10s // note: it is expected that collocation request should be reasonable fast
+  }
+
   metrics {
     # Should be unique for each service
     prefix = "com.socrata.data.coordinator"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.3.0"
     val soqlStdlib = "2.9.1"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.4.6"
+    val dataCoordinator = "3.4.7"
     val typesafeScalaLogging = "1.1.0"
     val rojomaJson = "3.5.0"
     val metricsJetty = "3.1.0"

--- a/store-pg/docker/Dockerfile
+++ b/store-pg/docker/Dockerfile
@@ -10,6 +10,7 @@ ENV SERVER_CONFIG secondary-watcher.conf
 
 # general secondary-watcher defaults
 ENV TRUTH_CLUSTER alpha
+ENV TRUTH_CLUSTER_COLLOCATION_GROUP [alpha]
 ENV ENABLE_GRAPHITE false
 ENV GRAPHITE_HOST 0.0.0.0
 ENV GRAPHITE_PORT 0
@@ -30,7 +31,7 @@ COPY $SERVER_ARTIFACT $SERVER_ROOT/
 
 ENV SECONDARY_CONFIG secondary.conf
 
-# geocoding-secondary-specific defaults
+# pg-secondary-specific defaults
 ENV PG_SECONDARY_DB_NAME falth
 ENV PG_SECONDARY_DB_PORT 5432
 ENV PG_SECONDARY_DB_USER soda_store

--- a/store-pg/docker/secondary-watcher.conf.j2
+++ b/store-pg/docker/secondary-watcher.conf.j2
@@ -3,6 +3,12 @@
 com.socrata.coordinator.secondary-watcher {
   instance = "{{ TRUTH_CLUSTER }}"
 
+  // TODO: is would be nice if the secondary-watcher message-producer could
+  // use this instead of its own zk configuration
+  curator.ensemble = {{ ZOOKEEPER_ENSEMBLE }}
+  service-advertisement.address = "{{ ARK_HOST }}"
+  collocation.group = {{ TRUTH_CLUSTER_COLLOCATION_GROUP }}
+
   # So we have good news and bad news.
   # The bad news is in the docker world we don't have the notion of an instance that will come back and 
   # reclaim its work based on its own uuid when it restarts, ever new container will have a new uuid.


### PR DESCRIPTION
Bring in new version of DC for updated SecondaryWatcher library
code that uses zookeeper lock to avoid race conditions when dropping
datasets from stores as part of collocation.