### PR TITLE
SPARTA: Fix start script for soql-server-pg

### DIFF
--- a/bin/start_soql_server_pg.sh
+++ b/bin/start_soql_server_pg.sh
@@ -5,7 +5,7 @@ set -e
 REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
 BINDIR=$(dirname "$REALPATH")
 
-CONFIG=${SODA_CONFIG:-/etc/pg-secondary.conf}
+CONFIG=${SODA_CONFIG:-"$BINDIR"/../configs/soql-postgres-adapter.conf}
 
 JARFILE=$("$BINDIR"/build.sh "$@" | grep '^soql-server-pg: ' | sed 's/^soql-server-pg: //')
 

--- a/configs/soql-postgres-adapter.conf
+++ b/configs/soql-postgres-adapter.conf
@@ -62,6 +62,7 @@ com.socrata.coordinator.common = {
   database = ${common-database} {
     database = "datacoordinator"
   }
+  curator = ${curator}
   instance = ${data-coordinator-instance}
   secondary {
     defaultGroups = [pg,spandex]

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -590,7 +590,7 @@ object QueryServer extends DynamicPortMap with Logging {
     new QueryServerConfig(withDefaultAddress(ConfigFactory.load()), "com.socrata.soql-server-pg")
   } catch {
     case e: Exception =>
-      logger.error(e.toString)
+      e.printStackTrace()
       sys.exit(1)
   }
 


### PR DESCRIPTION
Changes to the reference.conf in new data-coordinator
version must of removed the value for:

`com.socrata.datacoordinator.common.curator.ensemble`

Also add stack trace for debugging config issues instead of using
the logger which is not configured and thus does not work.