### PR TITLE
SPARTA: Remove old file for dynamic class loading

### DIFF
--- a/store-pg/src/main/resources/secondary-manifest.json
+++ b/store-pg/src/main/resources/secondary-manifest.json
@@ -1,4 +1,0 @@
-{
-    "class" : "com.socrata.pg.store.PGSecondary",
-    "name" : "pg"
-}


### PR DESCRIPTION
Since we don't load PGSecondary dynamically insto SecondaryWatcher
any more we don't need this old file for that.