### PR TITLE
EN-23103 Allow human address to be partial null like

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerLocationTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerLocationTest.scala
@@ -66,8 +66,8 @@ class SqlizerLocationTest extends SqlizerTest {
   test("location ctor") {
     val soql = """SELECT location('point (2.2 1.1)'::point, '101 Main St', 'Seattle', 'WA', '98104')"""
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT ST_AsBinary(((ST_GeomFromText(?, 4326)))),('{"address": ' || to_json(?::text)::text || ', "city": ' || to_json(?::text)::text || ', "state": ' || to_json(?::text)::text || ', "zip": ' || to_json(?::text)::text || '}') FROM t1""")
+    sql should be ("""SELECT ST_AsBinary(((ST_GeomFromText(?, 4326)))),(case when coalesce(?,?,?,?) is null then null else '{"address": ' || coalesce(to_json(?::text)::text, '""') || ', "city": ' || coalesce(to_json(?::text)::text, '""') || ', "state": ' || coalesce(to_json(?::text)::text, '""') || ', "zip": ' || coalesce(to_json(?::text)::text, '""') || '}' end) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    params should be (Seq("point (2.2 1.1)", "101 Main St", "Seattle", "WA", "98104"))
+    params should be (Seq("point (2.2 1.1)", "101 Main St", "Seattle", "WA", "98104", "101 Main St", "Seattle", "WA", "98104"))
   }
 }


### PR DESCRIPTION
{"address": “101 Main St”, "city": “Seattle”, "state": "", "zip": “98104” }

We keep the key of null components.  SODA1 has the same behavior.  It is simpler.