### PR TITLE
updating the reference to standard libraries to use the versions that…

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.1.2"
     val socrataThirdPartyUtils = "4.0.16"
     val socrataHttpCuratorBroker = "3.11.4"
-    val soqlStdlib = "2.11.6"
+    val soqlStdlib = "2.11.7"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.4.36"
     val typesafeScalaLogging = "1.1.0"


### PR DESCRIPTION
… reference an exact soql-brita version

soql-reference@2.11.7 was changed to reference soql-brita 1.4.1 (which is in artifactory) and to remove problematic range syntax that artifactory doesn't like.  This change update the soql-postgres-adapter project to use that newly built standard lib set.