### PR TITLE
Set the application name when getting a database connection.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/SecondaryBase.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/SecondaryBase.scala
@@ -7,6 +7,7 @@ import com.socrata.pg.store.{PostgresUniverseCommon, PGSecondaryUniverse}
 import com.socrata.soql.types.{SoQLValue, SoQLType}
 import com.socrata.datacoordinator.secondary.DatasetInfo
 import com.socrata.datacoordinator.common.DataSourceFromConfig.DSInfo
+import org.slf4j.MDC
 
 trait SecondaryBase {
 
@@ -21,8 +22,26 @@ trait SecondaryBase {
       conn <- managed(dsInfo.dataSource.getConnection)
     } yield {
       conn.setAutoCommit(false)
+      conn.setClientInfo("ApplicationName", applicationNameString)
       f(conn)
+      /* We are deliberately not clearing the application name afterwards to avoid the slight overhead of
+       * another call and because once in a while it can be useful to see on idle connections what the previous
+       * query was about, mirroring how postgres doesn't blank out the "query" field of pg_stat_activity after
+       * the query is finished.  All of the uses of this connection pool should go through this acquisition codepath
+       * which should avoid any cases of seeing a stale value on an active connection.
+       */
     }
+  }
+
+  private def applicationNameString: String = {
+    // Keep in mind that postgres limits the application_name to 64 chars (unless you recompile).
+    // The X-Socrata values are set in the MDC for logging in the query servers, while the "-id" values
+    // are set by the secondary watcher processes, so we use whichever we can find.
+    Thread.currentThread().getId() + " " +
+      Option(MDC.get("X-Socrata-RequestId")).orElse(Option(MDC.get("job-id"))).getOrElse("-") + " " +
+      // X-Socrata-Resource is set to the soda fountain resource name, not what the request came into core with.
+      // It would be nice to expose the 4x4 the request came into core with but that requires more plumbing work.
+      Option(MDC.get("X-Socrata-Resource")).orElse(Option(MDC.get("dataset-id"))).getOrElse("-")
   }
 
   protected def withPgu[T](dsInfo:DSInfo, truthStoreDatasetInfo:Option[DatasetInfo])


### PR DESCRIPTION
The main use case is for the query server so you can more easily
trace back queries to requests.  This also work in the secondary
watcher code, although is probably less helpful there.

This relies on existing values that are set in the MDC for logging purposes.

Example secondary watcher value: "79 b0a971c5-d3c5-438f-b030-c313f7ee64e8 DatasetId(5)"

Example query server value: "90 4t4jvi0k5qs8qmdxrsygiwr4l _8qy9-my8i"