### PR TITLE
Move the database migrations into store-pg's start script

### DIFF
--- a/soql-server-pg/docker/ship.d/run
+++ b/soql-server-pg/docker/ship.d/run
@@ -9,13 +9,6 @@ else
   /bin/env_parse ${SERVER_CONFIG}.j2
 fi
 
-su socrata -c '/usr/bin/java \
-    -Dconfig.file=${SERVER_CONFIG} \
-    -cp $SERVER_ARTIFACT \
-    com.socrata.pg.store.Main --migrate Migrate \
-    com.socrata.soql-server-pg.migrations \
-    '
-
 exec su socrata -c '/usr/bin/java \
     -Xmx${JAVA_XMX} \
     -Xms${JAVA_XMX} \

--- a/store-pg/docker/ship.d/run
+++ b/store-pg/docker/ship.d/run
@@ -12,6 +12,13 @@ else
   /bin/env_parse ${SECONDARY_CONFIG}.j2
 fi
 
+su socrata -c '/usr/bin/java \
+    -Dconfig.file=${SERVER_ROOT}/${SERVER_CONFIG} \
+    -cp $SERVER_ARTIFACT \
+    com.socrata.pg.store.Main --migrate Migrate \
+    com.socrata.soql-server-pg.migrations \
+    '
+
 exec su socrata -c '/usr/bin/java \
     -Xmx${JAVA_XMX} \
     -Xms${JAVA_XMX} \


### PR DESCRIPTION
soql-server-pg _uses_ store-pg to run the migrations but store-pg isn't
included in the jar file anymore because it otherwise didn't use it.

So now do the migrations that the store jar is responsible for when the
store jar is deployed