### PR TITLE
EN-37213 incorrect soql breaks stacked points in maps.

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -231,11 +231,10 @@ object SoQLAnalysisSqlizer extends Sqlizer[AnalysisTarget] {
           ParametricSql(Seq(groupByColumnPosition.toString), t2._2)
         } else {
           val psql@ParametricSql(ss, ps) = Sqlizer.sql(gb)(repMinusComplexJoinTable, typeRep, t2._2, ctxSelectWithJoins + (SoqlPart -> SoqlGroup), escape)
-          // add ST_AsBinary to geometry type to work around a slowness problem in postgis
-          // https://github.com/postgis/postgis/commit/8606a3164111e75754ce59c095a05e193cdae636
-          // appear to be fixed in postgis 2.4.0
-          if (shouldConvertGeomToText(ctx)) ParametricSql(ss.updated(0, toGeoText(ss.head, gb.typ, None)), ps)
-          else psql
+          // EN-37213 removing ST_AsBinary to geometric types because it creates invalid soql
+          // in derived views. Adding ST_AsBinary to a group by column changes the column name
+          // and as such will cause a column must be in group by.
+          psql
         }
       (t2._1 ++ sqls, newSetParams)
     }


### PR DESCRIPTION
Previous Behavior:
For geometric column types the ST_AsBinary function would be applied to a column on the group by. This changes the name of the column and in certain soql queries that use the `having` clause break. 

Example of old soql -> sql generated

`
GROUP BY   ST_AsBinary(t275_1_1.u_zki2_rzkk_24) 
HAVING ((((ST_within((ST_SnapToGrid(t275_1_1.u_zki2_rzkk_24, 0.00097656))
`
This causes a PSQLException: column not in group by.

**New Behavior**
`
GROUP BY   t275_1_1.u_zki2_rzkk_24
HAVING ((((ST_within((ST_SnapToGrid(t275_1_1.u_zki2_rzkk_24, 0.00097656))
`
