### PR TITLE
Change continuous median() so it works as a window function.

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20200210-add-median-function.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20200210-add-median-function.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Marc Slemko" id="20200210-add-median-function">
+        <sql splitStatements="false">
+            -- This is the second function on https://wiki.postgresql.org/wiki/Aggregate_Median as of 2020/02/10, with
+            -- the following modifications:
+            --
+            -- * Returns anyelement instead of hardcoding float8 to avoid unnecessary type conversions.  In the original
+            --   you could end up returning a value that wasn't in the dataset especially if the source data has already
+            --   been "enhanced" by misconceived floating type conversions outside the platform.
+            --
+            CREATE FUNCTION _final_median_ulib_agg(anyarray) RETURNS anyelement AS $$
+              WITH q AS
+              (
+                 SELECT val
+                 FROM unnest($1) val
+                 WHERE VAL IS NOT NULL
+                 ORDER BY 1
+              ),
+              cnt AS
+              (
+                SELECT COUNT(*) AS c FROM q
+              )
+              SELECT AVG(val)
+              FROM
+              (
+                SELECT val FROM q
+                LIMIT  2 - MOD((SELECT c FROM cnt), 2)
+                OFFSET GREATEST(CEIL((SELECT c FROM cnt) / 2.0) - 1,0)
+              ) q2;
+            $$ LANGUAGE SQL IMMUTABLE;
+
+            CREATE AGGREGATE median_ulib_agg(anyelement) (
+              SFUNC=array_append,
+              STYPE=anyarray,
+              FINALFUNC=_final_median_ulib_agg,
+              INITCOND='{}'
+            );
+        </sql>
+        <rollback>
+            <sql>
+                DROP AGGREGATE median_ulib_agg(anyelement);
+                DROP FUNCTION _final_median_ulib_agg(anyarray);
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -24,4 +24,5 @@
     <include file="com/socrata/pg/store/schema/20190522-add-dataset-map-latest-data-version.xml"/>
     <include file="com/socrata/pg/store/schema/20190601-create-index-directives.xml"/>
     <include file="com/socrata/pg/store/schema/20191224-add-some-dc-tables.xml"/>
+    <include file="com/socrata/pg/store/schema/20200210-add-median-function.xml"/>
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
@@ -152,7 +152,11 @@ object SqlFunctions extends SqlFunctionsLocation with SqlFunctionsGeometry with 
     Sum -> nary("sum") _,
     StddevPop -> nary("stddev_pop") _,
     StddevSamp -> nary("stddev_samp") _,
-    Median -> formatCall("percentile_cont(.50) within group (order by %s)") _,
+    // percentile_cont doesn't work as a window function so we are using a slightly modified function lifted
+    // from https://wiki.postgresql.org/wiki/Aggregate_Median for continuous median.  It can be significantly slower,
+    // hosever works as a window function.  We could write a similar one to replace percentile_disc if we had the need,
+    // but for now avoiding that effort and testing.
+    Median -> nary("median_ulib_agg") _,
     MedianDisc -> formatCall("percentile_disc(.50) within group (order by %s)") _,
 
     RowNumber -> nary("row_number") _,

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -169,9 +169,9 @@ class SqlizerBasicTest extends SqlizerTest {
   }
 
   test("select aggregate functions") {
-    val soql = "select count(id), avg(id), min(id), max(id), sum(id), median(id)"
+    val soql = "select count(id), avg(id), min(id), max(id), sum(id), median(id), median(case_number)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (count(t1.id)),(avg(t1.id)),(min(t1.id)),(max(t1.id)),(sum(t1.id)),(percentile_cont(.50) within group (order by t1.id)) FROM t1")
+    sql should be ("SELECT (count(t1.id)),(avg(t1.id)),(min(t1.id)),(max(t1.id)),(sum(t1.id)),(median_ulib_agg(t1.id)),(percentile_disc(.50) within group (order by t1.case_number)) FROM t1")
     setParams.length should be (0)
   }
 

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/MigrateSchema.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/MigrateSchema.scala
@@ -20,9 +20,9 @@ object MigrateSchema extends App {
   // Verify that two arguments were passed
   if (args.length < 1 || args.length > 2) {
     throw new IllegalArgumentException(
-      "Usage: com.socrata.pg.server.MigrateSchema" +
+      "Usage: com.socrata.pg.server.MigrateSchema " +
         MigrationOperation.values.mkString("|") +
-        "[<dotted path reference to database config in config>]")
+        " [<dotted path reference to database config in config>]")
   }
 
   // Verify that the argument provided is actually a valid operation


### PR DESCRIPTION
For now we are only doing this for the continuous median as that
is where our current use cases lie.

This implementation can be significantly slower.  Ideally we would
know if we were using it inside a window function or not so we could
switch implementations but that would take some more work.