### PR TITLE
Log the SQL exception we get on failed SQL.

### DIFF
--- a/soql-server-pg/src/main/scala/com/socrata/pg/query/DataSqlizerQuerier.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/query/DataSqlizerQuerier.scala
@@ -135,7 +135,7 @@ trait DataSqlizerQuerier[CT, CV] extends AbstractRepBasedDataSqlizer[CT, CV] {
       stmt.executeQuery()
     } catch {
       case ex: SQLException =>
-        logger.error(s"SQL Exception (${ex.getSQLState}) with timeout=$timeout on $pSql")
+        logger.error(s"SQL Exception (${ex.getSQLState}) with timeout=$timeout on $pSql", ex)
         throw ex
     }
   }
@@ -184,7 +184,7 @@ trait DataSqlizerQuerier[CT, CV] extends AbstractRepBasedDataSqlizer[CT, CV] {
       stmt.executeQuery()
     } catch {
       case ex: SQLException =>
-        logger.error(s"SQL Exception (${ex.getSQLState}) with timeout=$timeout on $pSql")
+        logger.error(s"SQL Exception (${ex.getSQLState}) with timeout=$timeout on $pSql", ex)
         throw ex
     }
   }


### PR DESCRIPTION
This gets logged many layers up the stack by the CountingHandler in socrata-http
however that is outside the ThreadRenamingHandler that gives context like request id
to the log line making it hard to find when there are many requests.

This will result in the exception being logged twice, once here and once by CountingHandler.
The correct fix for that would be to not bubble unhandled exceptions up to CountingHandler and
have a saner error handling framework within this code but that is a much bigger change to make
in a way that makes things cleaner and not just more convoluted.