### PR TITLE
EN-38580: when composing query for text search, attempt to use index

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/index/FullTextSearch.scala
@@ -1,11 +1,12 @@
 package com.socrata.pg.store.index
 
+import com.socrata.datacoordinator.id.UserColumnId
 import com.socrata.datacoordinator.truth.sql.SqlColumnCommonRep
 import com.socrata.pg.soql.Sqlizer._
 import com.socrata.pg.soql.SqlizerContext._
 import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.{ColumnName, TableName}
-import com.socrata.soql.typed.CoreExpr
+import com.socrata.soql.typed.{ColumnRef, CoreExpr}
 import com.socrata.soql.types.SoQLUrl
 
 trait FullTextSearch[CT] {
@@ -23,19 +24,29 @@ trait FullTextSearch[CT] {
     val phyCols = repsSearchableTypes.flatMap(rep => rep.physColumns.map(phyCol =>
       coalesce(ctx.map(qualify(phyCol, _)).getOrElse(phyCol))
     ))
-    toTsVector(phyCols)
+    toTsVector(phyCols.zip(phyCols))
   }
 
-  def searchVector(selection: OrderedMap[ColumnName, CoreExpr[_, CT]], ctx: Option[Context]): Option[String] = {
-    val cols = selection.view.filter(x => SearchableTypes.contains(x._2.typ)).flatMap { case (columnName, expr) =>
+  def searchVector(selection: OrderedMap[ColumnName, CoreExpr[UserColumnId, CT]], ctx: Option[Context]): Option[String] = {
+    val colSortAndCols: Seq[(String, String)] = selection.view.filter(x => SearchableTypes.contains(x._2.typ)).flatMap { case (columnName, expr) =>
       val subColumns = typeSubColumns(expr.typ)
+
+      // make sure the ts vector column ordering matches the index, if possible
+      // index is created with the true column name (ex: u_6tcq_mbxm_28) alphabetically
+      val columnNameForSort: String = expr match {
+        case cr: ColumnRef[UserColumnId, CT] => cr.column.underlying // this is not strictly the true column name, but should be sufficient for ordering
+        case _ => columnName.name // if these aren't all ColumnRefs, sorting isn't going to get us an index match anyway
+      }
+
       subColumns.map { sc =>
         val subColumnName = s"${columnName.name}${sc}"
         val qualifiedSubColumnName = ctx.map(c => qualify(subColumnName, c)).getOrElse(subColumnName)
-        coalesce(qualifiedSubColumnName)
+
+        (s"${columnNameForSort}${sc}", coalesce(qualifiedSubColumnName))
       }
-    }
-    toTsVector(cols.toSeq)
+    }.toSeq
+
+    toTsVector(colSortAndCols)
   }
 
   def searchNumericVector(selection: OrderedMap[ColumnName, CoreExpr[_, CT]], ctx: Option[Context]): Seq[String] = {
@@ -66,9 +77,12 @@ trait FullTextSearch[CT] {
     s"coalesce($col,'')"
   }
 
-  private def toTsVector(cols: Seq[String]): Option[String] = {
-    if (cols.isEmpty) None
-    else Some(cols.sorted.mkString("to_tsvector('english', ", " || ' ' || ", ")"))
+  /**
+    * First element of the tuple indicates sort order for the column
+    */
+  private def toTsVector(colSortAndCols: Seq[(String, String)]): Option[String] = {
+    if (colSortAndCols.isEmpty) None
+    else Some(colSortAndCols.sortBy(_._1).map(_._2).mkString("to_tsvector('english', ", " || ' ' || ", ")"))
   }
 
   private def typeSubColumns(t: CT): Seq[String] = {


### PR DESCRIPTION
* the to_tsvector search index created on secondaries has the columns ordered by their actual table column names
* however, the search query path works with column aliases, and used to order by those (missing the index)
* this updates the searchVector to attempt an ordering that will hit the index. It uses the underlying column id (ex: '6tcq_mbxm'), plus any subcolumn suffix to determine the order. This is not strictly the true column name (ex: u_6tcq_mbxm_28) but will work for ordering.
* if not all the CoreExpr in the searchVector are ColumnRefs, its not going to be possible for us to use any index anyway.