### PR TITLE
EN-40387: Not selecting group by constant result in error

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -395,17 +395,20 @@ class SqlizerBasicTest extends SqlizerTest {
     params should be(Seq("oNe"))
   }
 
-  test("group by literals") {
+  test("group by literals with constants removed") {
     val soql = "select id, 'stRing' as a, 5 as b, 2*3 as c group by id, a, b, c"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be ("SELECT t1.id,e'stRing',5,(2 * 3) FROM t1 GROUP BY t1.id")
     setParams.length should be (0)
   }
 
-  test("group by literals all removed") {
+  /**
+    * This is an edge case of a pretty useless query.
+    */
+  test("group by all literals and constants stay when everything is a constant") {
     val soql = "select 'stRing' as a, 5 as b, 2*3 as c group by a, b, c"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT e'stRing',5,(2 * 3) FROM t1")
+    sql should be ("SELECT e'stRing',5,(2 * 3) FROM t1 GROUP BY 1,2,3")
     setParams.length should be (0)
   }
 

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -395,10 +395,17 @@ class SqlizerBasicTest extends SqlizerTest {
     params should be(Seq("oNe"))
   }
 
-  test("group by literal") {
+  test("group by literals") {
     val soql = "select id, 'stRing' as a, 5 as b, 2*3 as c group by id, a, b, c"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.id,e'stRing',5,(2 * 3) FROM t1 GROUP BY t1.id,2,3,4")
+    sql should be ("SELECT t1.id,e'stRing',5,(2 * 3) FROM t1 GROUP BY t1.id")
+    setParams.length should be (0)
+  }
+
+  test("group by literals all removed") {
+    val soql = "select 'stRing' as a, 5 as b, 2*3 as c group by a, b, c"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT e'stRing',5,(2 * 3) FROM t1")
     setParams.length should be (0)
   }
 

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLGroupTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLGroupTest.scala
@@ -28,4 +28,8 @@ class SoQLGroupTest extends SoQLTest {
   test("group by text fn") {
     compareSoqlResult("select country || '''s ' || make as brand_made, count(name) group by country || '''s ' || make order by country || '''s ' || make", "group-text-expr.json", caseSensitivity = CaseInsensitive)
   }
+
+  test("group by constant") {
+    compareSoqlResult("select upper(make) as umake, 'one' as constant, count(name) as count_name group by upper(make), constant order by upper(make) |> select umake, count_name", "group-text.json")
+  }
 }


### PR DESCRIPTION
QA: To repro:
1. create soql view - select field, ' ' as constant group by field, constant
2. $query=select field -> error