### PR TITLE
EN-42578: Plug rollup table leak

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -459,7 +459,7 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
 
     val postUpdateTruthCopyInfo = pgu.datasetMapReader.latest(truthDatasetInfo)
     // Rollups do not materialize if stage is unpublished.
-    if (postUpdateTruthCopyInfo.lifecycleStage == LifecycleStage.Published) {
+    if (RollupManager.shouldMaterializeRollups(postUpdateTruthCopyInfo.lifecycleStage)) {
       maybeLogTime("Refreshing rollups") {
         updateRollups(pgu,
                       previouslyPublishedTruthCopyInfo,

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandler.scala
@@ -51,7 +51,7 @@ case class WorkingCopyCreatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValu
           RollupCreatedOrUpdatedHandler(pgu, newCopyInfo, sru)
         }
         pgu.datasetMapReader.rollups(newCopyInfo).foreach { ru =>
-          rm.updateRollup(ru, newCopyInfo.dataVersion)
+          rm.updateRollup(ru, Some(truthCopyInfo), newCopyInfo.dataVersion)
         }
       }
   }

--- a/store-pg/src/test/scala/com/socrata/pg/store/DatabaseTestBase.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/DatabaseTestBase.scala
@@ -114,7 +114,7 @@ trait DatabaseTestBase {
   def createRollup(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: CopyInfo): String = {
     val rollupInfo = pgu.datasetMapWriter.createOrUpdateRollup(copyInfo, new RollupName("roll1"), "select 'x'")
     val rm = new RollupManager(pgu, copyInfo)
-    rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+    rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
     val rollupTableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
     pgu.commit()
     rollupTableName

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -31,7 +31,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
         "select * (EXCEPT _point, _multipolygon, _location, _phone)")
 
       val rm = new RollupManager(pgu, copyInfo)
-      rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+      rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
 
@@ -50,7 +50,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       val rollupInfo = pgu.datasetMapWriter.createOrUpdateRollup(copyInfo, new RollupName("roll1"), "select _point, _multipolygon, _polygon, _line, _multipoint")
 
       val rm = new RollupManager(pgu, copyInfo)
-      rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+      rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
 
@@ -71,7 +71,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
         "select _make, avg(_aspect_ratio) AS _avg_asp WHERE _v_min >20 GROUP BY _make HAVING _avg_asp > 4 ORDER BY _make limit 100 offset 1")
 
       val rm = new RollupManager(pgu, copyInfo)
-      rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+      rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
       jdbcColumnCount(pgu.conn, tableName) should be (2)
@@ -91,7 +91,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
         "select I am a monkey GROUP BY monkeyland")
 
       val rm = new RollupManager(pgu, copyInfo)
-      rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+      rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
       jdbcColumnCount(pgu.conn, tableName) should be (0)
@@ -129,7 +129,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       RollupManager.makeSecondaryRollupInfo(rollupInFirstCopy) should be (rollup)
 
       // create the rollup table
-      (new RollupManager(pgu, firstCopyPublished)).updateRollup(rollupInFirstCopy, firstCopy.dataVersion)
+      (new RollupManager(pgu, firstCopyPublished)).updateRollup(rollupInFirstCopy, None, firstCopy.dataVersion)
 
       val tableNameFirstCopy = RollupManager.rollupTableName(rollupInFirstCopy, firstCopy.dataVersion)
       jdbcColumnCount(pgu.conn, tableNameFirstCopy) should be (1)
@@ -149,7 +149,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       val rollupsInSecondCopy = pgu.datasetMapReader.rollups(secondCopyPublished)
       rollupsInSecondCopy.size should be (1)
       val rollupInSecondCopy = rollupsInSecondCopy.head
-      (new RollupManager(pgu, secondCopyPublished)).updateRollup(rollupInSecondCopy, secondCopyPublished.dataVersion)
+      (new RollupManager(pgu, secondCopyPublished)).updateRollup(rollupInSecondCopy, Some(secondCopy), secondCopyPublished.dataVersion)
       RollupManager.makeSecondaryRollupInfo(rollupInSecondCopy) should be (rollup)
 
       val tableNameSecondCopy = RollupManager.rollupTableName(rollupInSecondCopy, secondCopy.dataVersion)
@@ -203,7 +203,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       RollupCreatedOrUpdatedHandler(pgu, truthCopyInfo, rollup)
       val rm = new RollupManager(pgu, truthCopyInfo)
       pgu.datasetMapReader.rollups(truthCopyInfo).foreach { ru =>
-        rm.updateRollup(ru, truthCopyInfo.dataVersion)
+        rm.updateRollup(ru, None, truthCopyInfo.dataVersion)
       }
 
       val rows2 = rows :+
@@ -263,7 +263,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       RollupManager.makeSecondaryRollupInfo(rollupInFirstCopy) should be (rollup)
 
       // create the rollup table
-      (new RollupManager(pgu, firstCopyPublished)).updateRollup(rollupInFirstCopy, firstCopy.dataVersion)
+      (new RollupManager(pgu, firstCopyPublished)).updateRollup(rollupInFirstCopy, None, firstCopy.dataVersion)
 
       val tableNameFirstCopy = RollupManager.rollupTableName(rollupInFirstCopy, firstCopy.dataVersion)
       jdbcColumnCount(pgu.conn, tableNameFirstCopy) should be (1)
@@ -301,7 +301,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
         "select _make, avg(_aspect_ratio) over(partition by _make)  AS _avg_asp")
 
       val rm = new RollupManager(pgu, copyInfo)
-      rm.updateRollup(rollupInfo, copyInfo.dataVersion)
+      rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
 
       val tableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
       jdbcColumnCount(pgu.conn, tableName) should be (2)


### PR DESCRIPTION
The code assumed that data versions would increase by 1 each time; this
is no longer true.  Instead, fetch the previous data version from the
database.

Also remove the 0-row optimization, because it will break things (the
data version will still be changed, and therefore the table name)