### PR TITLE
Don't drop rollups that get created during resync

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/PGSecondary.scala
@@ -617,8 +617,10 @@ class PGSecondary(val config: Config) extends Secondary[SoQLType, SoQLValue] wit
       IndexDirectiveCreatedOrUpdatedHandler(pgu, idx.columnInfo, idx.directive)
     }
 
-    // re-create rollup tables
-    updateRollups(pgu, Some(truthCopyInfo), postUpdateTruthCopyInfo)
+    // re-create rollup tables.  We don't need to pass in an old truth
+    // because we just dropped any existing rollups above.
+    updateRollups(pgu, None, postUpdateTruthCopyInfo)
+
     pgu.datasetMapWriter.enableDataset(truthCopyInfo.datasetInfo.systemId) // re-enable soql reads
     cookie
   }


### PR DESCRIPTION
If this resync was creating a new dataset from scratch (e.g., if there
was a collocation or the like to put a dataset in a secondary without
the log existing) it would create a rollup and then promptly schedule
it for dropping.