### PR TITLE
EN-44281: Union/Query BinaryTree Rollup not used fix

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/ExprSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/ExprSqlizer.scala
@@ -197,52 +197,52 @@ object ColumnRefSqlizer extends Sqlizer[ColumnRef[UserColumnId, SoQLType]] {
 
     val ista = isTableAlias(expr.qualifier, simpleJoinMap)
 
-    if (useTypeRep) {
-      val typeReps = typeRep ++ // TODO: Adding reps seems unnecessary but keep to minimize change for now
-        reps.values.map((rep: SqlColumnRep[SoQLType, SoQLValue]) => (rep.representedType -> rep)).toMap
-      typeReps.get(expr.typ) match {
-        case Some(rep) =>
-          val subColumns = rep.physColumns.map { pc => pc.replace(rep.base, "") }
-          val sqls = subColumns.map { subCol =>
-            val c = idQuote(expr.column.underlying + subCol)
-            expr.qualifier.foreach(qualifierRx.findFirstMatchIn(_).orElse(throw BadParse("Invalid table alias", expr.position)))
-            val qualifier = expr.qualifier.orElse(ctx.get(PrimaryTableAlias).map(_.toString))
-            toUpper(expr)(qualifier.map(q => s"$q.$c").getOrElse(c), ctx) + selectAlias(expr, Some(subCol))(ctx)
+    reps.get(QualifiedUserColumnId(expr.qualifier, expr.column)) match {
+      case Some(rep) if !useTypeRep =>
+        if (complexTypes.contains(expr.typ) &&
+          ctx.get(SoqlPart).exists(_ == SoqlSelect) &&
+          ctx.get(RootExpr).exists(_ == expr)) {
+          val qualifer = tableMap.get(expr.qualifier.getOrElse(TableName.PrimaryTable.qualifier))
+          val maybeUpperPhysColumns =
+            rep.physColumns.zip(rep.sqlTypes).map { case (physCol, sqlType) =>
+              toUpper(expr, sqlType)(qualifer.map(q => s"$q.$physCol").getOrElse(physCol), ctx)
+            }
+          val subColumns = rep.physColumns.map(pc => pc.replace(rep.base, ""))
+          val physColumnsWithSubColumns = maybeUpperPhysColumns.zip(subColumns)
+          val columnsWithAlias = physColumnsWithSubColumns.map { case (physCol, subCol) =>
+            physCol + selectAlias(expr, Some(subCol))(ctx)
           }
-          ParametricSql(sqls, setParams)
-        case None =>
-          val schema = reps.map { case (columnId, rep) => (columnId.userColumnId.underlying -> rep.representedType) }
-          val soql = ctx.get(SoqlSelect).getOrElse("no select info")
-          throw new Exception(s"cannot find rep for ${expr.column.underlying} ${expr.typ}\n$soql\n${schema.toString}")
-      }
-    } else {
-      val rep = reps(QualifiedUserColumnId(expr.qualifier, expr.column))
-      if (complexTypes.contains(expr.typ) &&
-        ctx.get(SoqlPart).exists(_ == SoqlSelect) &&
-        ctx.get(RootExpr).exists(_ == expr)) {
-        val qualifer = tableMap.get(expr.qualifier.getOrElse(TableName.PrimaryTable.qualifier))
-        val maybeUpperPhysColumns =
-          rep.physColumns.zip(rep.sqlTypes).map { case (physCol, sqlType) =>
-            toUpper(expr, sqlType)(qualifer.map(q => s"$q.$physCol").getOrElse(physCol), ctx)
+          ParametricSql(columnsWithAlias, setParams)
+        } else {
+          val qualifier = expr.qualifier match {
+            case Some(x) =>
+              if (ista) expr.qualifier
+              else Some(tableMap(x))
+            case None =>
+              tableMap.get(TableName.PrimaryTable.qualifier)
           }
-        val subColumns = rep.physColumns.map(pc => pc.replace(rep.base, ""))
-        val physColumnsWithSubColumns = maybeUpperPhysColumns.zip(subColumns)
-        val columnsWithAlias = physColumnsWithSubColumns.map { case (physCol, subCol) =>
-          physCol + selectAlias(expr, Some(subCol))(ctx)
+          qualifier.foreach(qualifierRx.findFirstMatchIn(_).orElse(throw BadParse("Invalid table alias", expr.position)))
+          val maybeUpperPhysColumns = rep.physColumns.map(c => toUpper(expr)(qualifier.map(q => s"$q.$c").getOrElse(c), ctx))
+          ParametricSql(maybeUpperPhysColumns.map(c => c + selectAlias(expr)(ctx)), setParams)
         }
-        ParametricSql(columnsWithAlias, setParams)
-      } else {
-        val qualifier = expr.qualifier match {
-          case Some(x) =>
-            if (ista) expr.qualifier
-            else Some(tableMap(x))
+      case _ =>
+        val typeReps = typeRep ++ // TODO: Adding reps seems unnecessary but keep to minimize change for now
+          reps.values.map((rep: SqlColumnRep[SoQLType, SoQLValue]) => (rep.representedType -> rep)).toMap
+        typeReps.get(expr.typ) match {
+          case Some(rep) =>
+            val subColumns = rep.physColumns.map { pc => pc.replace(rep.base, "") }
+            val sqls = subColumns.map { subCol =>
+              val c = idQuote(expr.column.underlying + subCol)
+              expr.qualifier.foreach(qualifierRx.findFirstMatchIn(_).orElse(throw BadParse("Invalid table alias", expr.position)))
+              val qualifier = expr.qualifier.orElse(ctx.get(PrimaryTableAlias).map(_.toString))
+              toUpper(expr)(qualifier.map(q => s"$q.$c").getOrElse(c), ctx) + selectAlias(expr, Some(subCol))(ctx)
+            }
+            ParametricSql(sqls, setParams)
           case None =>
-            tableMap.get(TableName.PrimaryTable.qualifier)
+            val schema = reps.map { case (columnId, rep) => (columnId.userColumnId.underlying -> rep.representedType) }
+            val soql = ctx.get(SoqlSelect).getOrElse("no select info")
+            throw new Exception(s"cannot find rep for ${expr.column.underlying} ${expr.typ}\n$soql\n${schema.toString}")
         }
-        qualifier.foreach(qualifierRx.findFirstMatchIn(_).orElse(throw BadParse("Invalid table alias", expr.position)))
-        val maybeUpperPhysColumns = rep.physColumns.map(c => toUpper(expr)(qualifier.map(q => s"$q.$c").getOrElse(c), ctx))
-        ParametricSql(maybeUpperPhysColumns.map(c => c + selectAlias(expr)(ctx)), setParams)
-      }
     }
   }
 

--- a/common-pg/src/main/scala/com/socrata/pg/soql/ExprSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/ExprSqlizer.scala
@@ -225,7 +225,7 @@ object ColumnRefSqlizer extends Sqlizer[ColumnRef[UserColumnId, SoQLType]] {
           val maybeUpperPhysColumns = rep.physColumns.map(c => toUpper(expr)(qualifier.map(q => s"$q.$c").getOrElse(c), ctx))
           ParametricSql(maybeUpperPhysColumns.map(c => c + selectAlias(expr)(ctx)), setParams)
         }
-      case _ =>
+      case _ => // rollups also flow here by not finding entries in reps
         val typeReps = typeRep ++ // TODO: Adding reps seems unnecessary but keep to minimize change for now
           reps.values.map((rep: SqlColumnRep[SoQLType, SoQLValue]) => (rep.representedType -> rep)).toMap
         typeReps.get(expr.typ) match {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -434,12 +434,7 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
           acc ++ getJoinReps(pgu, copyInfo, tableName)
         }
 
-        val tableName = rollupName match {
-          case Some(_) =>
-            querier.sqlizer.dataTableName
-          case None =>
-            latestCopy.dataTableName
-        }
+        val tableName = querier.sqlizer.dataTableName
 
         if (explain) {
           val explain = querier.queryExplain(

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -434,6 +434,7 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
           acc ++ getJoinReps(pgu, copyInfo, tableName)
         }
 
+        // rollups will cause querier's dataTableName to be different than the normal dataset tablename
         val tableName = querier.sqlizer.dataTableName
 
         if (explain) {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -414,7 +414,6 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
       for(readCtx <- pgu.datasetReader.openDataset(latestCopy)) {
         val baseSchema: ColumnIdMap[ColumnInfo[SoQLType]] = readCtx.schema
         val systemToUserColumnMap = SchemaUtil.systemToUserColumnMap(readCtx.schema)
-        val tableName = latestCopy.dataTableName
         val qrySchema = querySchema(pgu, analyses.outputSchemaLeaf, latestCopy)
         val qryReps = qrySchema.mapValues(pgu.commonSupport.repFor)
         val querier = this.readerWithQuery(pgu.conn, pgu, readCtx.copyCtx, baseSchema, rollupName)
@@ -433,6 +432,13 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
         val sqlRepsWithJoin = joinCopiesMap.foldLeft(sqlReps) { (acc, joinCopy) =>
           val (tableName, copyInfo) = joinCopy
           acc ++ getJoinReps(pgu, copyInfo, tableName)
+        }
+
+        val tableName = rollupName match {
+          case Some(_) =>
+            querier.sqlizer.dataTableName
+          case None =>
+            latestCopy.dataTableName
         }
 
         if (explain) {


### PR DESCRIPTION
1. use rollup table name
2. use type rep if rep is not found