### PR TITLE
Get rollup by either dataset internal name or resource name (for QC)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.0.1"
+    val soqlStdlib = "3.0.2"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.8"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
Part of preparation to support multiple rollups because of the introduction of unions