### PR TITLE
Handle the single-row table special case

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20210420-create-onerow.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20210420-create-onerow.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+    <changeSet author="robertm" id="20210420-create-onerow">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="onerow"/>
+            </not>
+        </preConditions>
+        <sql>
+            CREATE TABLE onerow (col INT);
+            INSERT INTO onerow (col) VALUES (1);
+            ALTER TABLE onerow DROP COLUMN col;
+        </sql>
+        <rollback>
+            <sql>
+                DROP TABLE onerow;
+            </sql>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20210420-create-single_row.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20210420-create-single_row.xml
@@ -4,20 +4,20 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <changeSet author="robertm" id="20210420-create-onerow">
+    <changeSet author="robertm" id="20210420-create-single_row">
         <preConditions onFail="MARK_RAN">
             <not>
-                <tableExists tableName="onerow"/>
+                <tableExists tableName="single_row"/>
             </not>
         </preConditions>
         <sql>
-            CREATE TABLE onerow (col INT);
-            INSERT INTO onerow (col) VALUES (1);
-            ALTER TABLE onerow DROP COLUMN col;
+            CREATE TABLE single_row (col INT);
+            INSERT INTO single_row (col) VALUES (1);
+            ALTER TABLE single_row DROP COLUMN col;
         </sql>
         <rollback>
             <sql>
-                DROP TABLE onerow;
+                DROP TABLE single_row;
             </sql>
         </rollback>
     </changeSet>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -25,5 +25,5 @@
     <include file="com/socrata/pg/store/schema/20191224-add-some-dc-tables.xml"/>
     <include file="com/socrata/pg/store/schema/20200210-add-median-function.xml"/>
     <include file="com/socrata/pg/store/schema/20200901-create-index-directive-map.xml"/>
-    <include file="com/socrata/pg/store/schema/20210420-create-onerow.xml"/>
+    <include file="com/socrata/pg/store/schema/20210420-create-single_row.xml"/>
 </databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -25,4 +25,5 @@
     <include file="com/socrata/pg/store/schema/20191224-add-some-dc-tables.xml"/>
     <include file="com/socrata/pg/store/schema/20200210-add-median-function.xml"/>
     <include file="com/socrata/pg/store/schema/20200901-create-index-directive-map.xml"/>
+    <include file="com/socrata/pg/store/schema/20210420-create-onerow.xml"/>
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -25,7 +25,7 @@ object BinarySoQLAnalysisSqlizer extends Sqlizer[(BinaryTree[SoQLAnalysis[UserCo
           ctx: Context,
           escape: Escape): ParametricSql = {
     val (analysis, tableNamesRaw, allColumnReps) = analysisTablesReps
-    val tableNames = tableNamesRaw + (TableName(TableName.SingleRow) -> "onerow")
+    val tableNames = tableNamesRaw + (TableName(TableName.SingleRow) -> "single_row")
     val primaryTable = tableNames(TableName.PrimaryTable)
     val analysisWithFrom = updateFrom(analysis, TableName(primaryTable))
     val tableNamesWithPrimaryTable = tableNames + (TableName(primaryTable) -> primaryTable)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -501,4 +501,10 @@ class SqlizerBasicTest extends SqlizerTest {
     params should be (Seq("foo"))
 
   }
+
+  test("simple single row does not generate a from clause") {
+    val soql = "select 'bleh' from @single_row"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT ?")
+  }
 }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -19,6 +19,24 @@ class SqlizerJoinTest  extends SqlizerTest {
     setParams.length should be (0)
   }
 
+  test("joined single row does generate a from clause") {
+    val soql = "select 'bleh' from @single_row join @year as y on true"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT ? FROM onerow JOIN t3 as _y ON ?")
+  }
+
+  test("join to singlerow") {
+    val soql = "select 'bleh' join @single_row on true"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT ? FROM t1 JOIN onerow ON ?")
+  }
+
+  test("join to singlerow in subselect") {
+    val soql = "select 'bleh' join (select 1, 2, 3 from @single_row) as vars on true"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    sql should be ("SELECT ? FROM t1 JOIN (SELECT ? as \"_1\",? as \"_2\",? as \"_3\") as _vars ON ?")
+  }
+
   test("join and chain") {
     val soql = "select case_number, primary_type, @y.avg_temperature join @year as y on @y.year = year |> select count(*)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -22,16 +22,16 @@ class SqlizerJoinTest  extends SqlizerTest {
   test("joined single row does generate a from clause") {
     val soql = "select 'bleh' from @single_row join @year as y on true"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ? FROM onerow JOIN t3 as _y ON ?")
+    sql should be ("SELECT ? FROM single_row JOIN t3 as _y ON ?")
   }
 
-  test("join to singlerow") {
+  test("join to single_row") {
     val soql = "select 'bleh' join @single_row on true"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ? FROM t1 JOIN onerow ON ?")
+    sql should be ("SELECT ? FROM t1 JOIN single_row ON ?")
   }
 
-  test("join to singlerow in subselect") {
+  test("join to single_row in subselect") {
     val soql = "select 'bleh' join (select 1, 2, 3 from @single_row) as vars on true"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be ("SELECT ? FROM t1 JOIN (SELECT ? as \"_1\",? as \"_2\",? as \"_3\") as _vars ON ?")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.3.1"
+    val soqlStdlib = "3.3.2"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.10"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
* Create a columnless `onerow` table we can reference
* Only actually generate that reference if necessary