### PR TITLE
Fix a bug in parameter bookkeeping in single_row elision

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
@@ -19,6 +19,9 @@ case class ParametricSql(sql: Seq[String], setParams: Seq[SetParam]) {
     "sql: " + sql.mkString(";") +
     " params: " + params.mkString("\"", """","""", "\"")
   }
+
+  val paramsAsStrings: Seq[String] =
+    setParams.map { (setParam) => setParam(None, 0).get.toString }
 }
 
 // scalastyle:off import.grouping


### PR DESCRIPTION
When converting a join into a from, keep track of the parameters
associated with that join more correctly (i.e., at all)