### PR TITLE
EN-46401 - round SoQL function

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
@@ -98,6 +98,7 @@ object SqlFunctions extends SqlFunctionsLocation with SqlFunctionsGeometry with 
     Absolute -> nary("abs") _,
     Ceiling -> nary("ceil") _,
     Floor -> nary("floor") _,
+    Round -> formatCall("round(%s, CAST(%s as INT))") _,
 
     FloatingTimeStampTruncYmd -> formatCall("date_trunc('day', %s)") _,
     FloatingTimeStampTruncYm -> formatCall("date_trunc('month', %s)") _,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.4.1"
+    val soqlStdlib = "3.4.3"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.10"
     val typesafeScalaLogging = "3.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.4.3"
+    val soqlStdlib = "3.4.4"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.10"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
Introduces:
`round(N, x)` function to round a number to the nearest x digits.
E.g.
round(3.1415, 3) => 3.142
round(315, -1) => 320