### PR TITLE
Update for new table aliases

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -104,7 +104,7 @@ object BinarySoQLAnalysisSqlizer extends Sqlizer[(BinaryTree[SoQLAnalysis[UserCo
             case _ =>
               (TableName.PrimaryTable, "x1")
           }
-        val subTableName = if (ra.from.isEmpty) "(%s) AS %s".format(lpsql.sql.head, chainedTableAlias)
+        val subTableName = if (ra.from.isEmpty) "(%s) AS \"%s\"".format(lpsql.sql.head, chainedTableAlias)
                            else "(%s)".format(lpsql.sql.head)
         val tableNamesSubTableNameReplace = tableNames + (primaryTableName -> subTableName)
         val primaryTableAlias = if (ra.joins.nonEmpty) Map((PrimaryTableAlias -> chainedTableAlias)) else Map.empty // REVISIT
@@ -375,13 +375,13 @@ trait SoQLAnalysisSqlizer {
           val repJoin = if (join.lateral) repFrom ++ rep else rep
           val joinTableLikeParamSql = Sqlizer.sql(
             (analyses, joinTableNames, allColumnReps))(repJoin, typeRep, Seq.empty, ctxJoin, escape)
-          val tn = "(" + joinTableLikeParamSql.sql.mkString + ") as " + alias
+          val tn = "(" + joinTableLikeParamSql.sql.mkString + ") as \"" + alias + "\""
           (tn, joinTableLikeParamSql.setParams)
         case Left(tableName) =>
           val key = TableName(tableName.name, None)
           val realTableName = tableNames(key)
           val qualifier = tableName.qualifier
-          val tn = if (tableName.alias.isEmpty) realTableName else s"$realTableName as $qualifier"
+          val tn = if (tableName.alias.isEmpty) realTableName else s"""$realTableName as "$qualifier""""
           (tn, Nil)
       }
 
@@ -469,7 +469,7 @@ trait SoQLAnalysisSqlizer {
          joinPhrases.tail, joinSetParamses.tail.flatten)
       } else {
         val (joinPhrases, joinSetParamses) = joinPhrasesAndParams.unzip
-        (s" FROM ${tableNamesWithThis(tableName.copy(alias = None))}" + tableName.alias.map(a => s" as ${a}").getOrElse(""), Nil,
+        (s" FROM ${tableNamesWithThis(tableName.copy(alias = None))}" + tableName.alias.map(a => s""" as "${a}"""").getOrElse(""), Nil,
          joinPhrases, joinSetParamses.flatten)
       }
 

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -18,7 +18,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("field in (x, y...)") {
     val soql = "select case_number where case_number in ('ha001', 'ha002', 'ha003') order by case_number offset 1 limit 2"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.case_number FROM t1 WHERE (t1.case_number in(?,?,?)) ORDER BY t1.case_number nulls last LIMIT 2 OFFSET 1")
+    sql should be ("""SELECT "t1".case_number FROM t1 WHERE ("t1".case_number in(?,?,?)) ORDER BY "t1".case_number nulls last LIMIT 2 OFFSET 1""")
     setParams.length should be (3)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("ha001", "ha002", "ha003"))
@@ -27,7 +27,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("field in (x, y...) ci") {
     val soql = "select case_number where case_number in ('ha001', 'ha002', 'ha003') order by case_number offset 1 limit 2"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseInsensitive)
-    sql should be ("SELECT t1.case_number FROM t1 WHERE (upper(t1.case_number) in(?,?,?)) ORDER BY upper(t1.case_number) nulls last LIMIT 2 OFFSET 1")
+    sql should be ("""SELECT "t1".case_number FROM t1 WHERE (upper("t1".case_number) in(?,?,?)) ORDER BY upper("t1".case_number) nulls last LIMIT 2 OFFSET 1""")
     setParams.length should be (3)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("HA001", "HA002", "HA003"))
@@ -36,23 +36,23 @@ class SqlizerBasicTest extends SqlizerTest {
   test("point/line/polygon") {
     val soql = "select case_number, point, line, polygon"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.case_number,ST_AsBinary(t1.point),ST_AsBinary(t1.line),ST_AsBinary(t1.polygon) FROM t1")
+    sql should be ("""SELECT "t1".case_number,ST_AsBinary("t1".point),ST_AsBinary("t1".line),ST_AsBinary("t1".polygon) FROM t1""")
     setParams.length should be (0)
   }
 
   test("extent") {
     val soql = "select extent(point), extent(multiline), extent(multipolygon)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Multi(ST_Extent(t1.point)))),ST_AsBinary((ST_Multi(ST_Extent(t1.multiline)))),ST_AsBinary((ST_Multi(ST_Extent(t1.multipolygon)))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Multi(ST_Extent("t1".point)))),ST_AsBinary((ST_Multi(ST_Extent("t1".multiline)))),ST_AsBinary((ST_Multi(ST_Extent("t1".multipolygon)))) FROM t1""")
     setParams.length should be (0)
   }
 
   test("concave hull") {
     val soql = "select concave_hull(point, 0.99), concave_hull(multiline, 0.89), concave_hull(multipolygon, 0.79)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union(t1.point), ?))))," +
-      "ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union(t1.multiline), ?))))," +
-      "ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union(t1.multipolygon), ?)))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union("t1".point), ?)))),""" +
+      """ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union("t1".multiline), ?)))),""" +
+      """ST_AsBinary((ST_Multi(ST_ConcaveHull(ST_Union("t1".multipolygon), ?)))) FROM t1""")
     setParams.length should be (3)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(0.99, 0.89, 0.79).map(BigDecimal(_)))
@@ -61,16 +61,16 @@ class SqlizerBasicTest extends SqlizerTest {
   test("convex hull") {
     val soql = "select convex_hull(point), convex_hull(multiline), convex_hull(multipolygon)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union(t1.point)))))," +
-      "ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union(t1.multiline)))))," +
-      "ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union(t1.multipolygon))))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union("t1".point))))),""" +
+      """ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union("t1".multiline))))),""" +
+      """ST_AsBinary((ST_Multi(ST_ConvexHull(ST_Union("t1".multipolygon))))) FROM t1""")
     setParams.length should be (0)
   }
 
   test("intersects") {
     val soql = "select intersects(point, 'MULTIPOLYGON (((1 1, 2 1, 2 2, 1 2, 1 1)))')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_Intersects(t1.point, (ST_GeomFromText(?, 4326)))) FROM t1")
+    sql should be ("""SELECT (ST_Intersects("t1".point, (ST_GeomFromText(?, 4326)))) FROM t1""")
     setParams.length should be (1)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("MULTIPOLYGON (((1 1, 2 1, 2 2, 1 2, 1 1)))"))
@@ -79,7 +79,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("distance in meters") {
     val soql = "select distance_in_meters(point, 'POINT(0 0)')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_Distance(t1.point::geography, (ST_GeomFromText(?, 4326))::geography)) FROM t1")
+    sql should be ("""SELECT (ST_Distance("t1".point::geography, (ST_GeomFromText(?, 4326))::geography)) FROM t1""")
     setParams.length should be (1)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("POINT(0 0)"))
@@ -88,14 +88,14 @@ class SqlizerBasicTest extends SqlizerTest {
   test("number of points") {
     val soql = "select num_points(multipolygon)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_NPoints(t1.multipolygon)) FROM t1")
+    sql should be ("""SELECT (ST_NPoints("t1".multipolygon)) FROM t1""")
     setParams.length should be (0)
   }
 
   test("is empty") {
     val soql = "select is_empty(multipolygon)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    val expected = "SELECT (ST_IsEmpty(t1.multipolygon) or t1.multipolygon is null) FROM t1"
+    val expected = """SELECT (ST_IsEmpty("t1".multipolygon) or "t1".multipolygon is null) FROM t1"""
     sql.replaceAll("\\s+", " ") should be (expected)
     setParams.length should be (0)
   }
@@ -104,11 +104,11 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select visible_at(multipolygon, 0.03)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val expected =
-      """SELECT ((NOT ST_IsEmpty(t1.multipolygon))
-        |     AND (ST_GeometryType(t1.multipolygon) = 'ST_Point'
-        |     OR ST_GeometryType(t1.multipolygon) = 'ST_MultiPoint'
-        |     OR (ST_XMax(t1.multipolygon) - ST_XMin(t1.multipolygon)) >= ?
-        |     OR (ST_YMax(t1.multipolygon) - ST_YMin(t1.multipolygon)) >= ?) )
+      """SELECT ((NOT ST_IsEmpty("t1".multipolygon))
+        |     AND (ST_GeometryType("t1".multipolygon) = 'ST_Point'
+        |     OR ST_GeometryType("t1".multipolygon) = 'ST_MultiPoint'
+        |     OR (ST_XMax("t1".multipolygon) - ST_XMin("t1".multipolygon)) >= ?
+        |     OR (ST_YMax("t1".multipolygon) - ST_YMin("t1".multipolygon)) >= ?) )
         | FROM t1""".stripMargin.replaceAll("\\s+", " ")
     sql.replaceAll("\\s+", " ") should be (expected)
     setParams.length should be (2)
@@ -119,7 +119,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("expr and expr") {
     val soql = "select id where id = 1 and case_number = 'cn001'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.id FROM t1 WHERE ((t1.id = ?) and (t1.case_number = ?))")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE (("t1".id = ?) and ("t1".case_number = ?))""")
     setParams.length should be (2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(1, "cn001"))
@@ -128,7 +128,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("expr and expr ci") {
     val soql = "select id where id = 1 and case_number = 'cn001'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseInsensitive)
-    sql should be ("SELECT t1.id FROM t1 WHERE ((t1.id = ?) and (upper(t1.case_number) = ?))")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE (("t1".id = ?) and (upper("t1".case_number) = ?))""")
     setParams.length should be (2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(1, "CN001"))
@@ -137,7 +137,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("starts_with has automatic suffix %") {
     val soql = "select id where starts_with(case_number, 'cn')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.id FROM t1 WHERE (t1.case_number like (? || ?))")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE ("t1".case_number like (? || ?))""")
     setParams.length should be (2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("cn", "%"))
@@ -146,7 +146,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("starts_with has automatic suffix % ci") {
     val soql = "select id where starts_with(case_number, 'cn')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseInsensitive)
-    sql should be ("SELECT t1.id FROM t1 WHERE (upper(t1.case_number) like (? || ?))")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE (upper("t1".case_number) like (? || ?))""")
     setParams.length should be (2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("CN", "%"))
@@ -155,7 +155,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("between") {
     val soql = "select id where id between 1 and 9"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.id FROM t1 WHERE (t1.id between ? and ?)")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE ("t1".id between ? and ?)""")
     setParams.length should be (2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(1, 9))
@@ -171,14 +171,14 @@ class SqlizerBasicTest extends SqlizerTest {
   test("select aggregate functions") {
     val soql = "select count(id), avg(id), min(id), max(id), sum(id), median(id), median(case_number)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ((count(t1.id))::numeric),(avg(t1.id)),(min(t1.id)),(max(t1.id)),(sum(t1.id)),(percentile_cont(.50) within group (order by t1.id)),(percentile_disc(.50) within group (order by t1.case_number)) FROM t1")
+    sql should be ("""SELECT ((count("t1".id))::numeric),(avg("t1".id)),(min("t1".id)),(max("t1".id)),(sum("t1".id)),(percentile_cont(.50) within group (order by "t1".id)),(percentile_disc(.50) within group (order by "t1".case_number)) FROM t1""")
     setParams.length should be (0)
   }
 
   test("select median inside window function") {
     val soql = "select median(id) over (partition by primary_type, year)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (median_ulib_agg(t1.id) over( partition by t1.primary_type,t1.year)) FROM t1")
+    sql should be ("""SELECT (median_ulib_agg("t1".id) over( partition by "t1".primary_type,"t1".year)) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -194,7 +194,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("search") {
     val soql = "select * search 'oNe Two'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive, useRepsWithId = true)
-    sql should be ("""SELECT t1.array_12,t1.object_11,ST_AsBinary(t1.multipoint_18),t1.phone_20_number,t1.phone_20_type,t1.year_8,ST_AsBinary(t1.multiline_14),t1.json_23,t1.arrest_9,ST_AsBinary(t1.multipolygon_15),ST_AsBinary(t1.polygon_16),t1.case_number_6,t1.updated_on_10,ST_AsBinary(t1.point_13),t1.id_5,t1.document_22,ST_AsBinary(t1.location_19_geom),t1.location_19_address,t1.primary_type_7,t1.url_21_url,t1.url_21_description,ST_AsBinary(t1.line_17) FROM t1 WHERE (to_tsvector('english', coalesce(t1.array_12,'') || ' ' || coalesce(t1.case_number_6,'') || ' ' || coalesce(t1.object_11,'') || ' ' || coalesce(t1.primary_type_7,'') || ' ' || coalesce(t1.url_21_description,'') || ' ' || coalesce(t1.url_21_url,'')) @@ plainto_tsquery('english', ?))""")
+    sql should be ("""SELECT "t1".array_12,"t1".object_11,ST_AsBinary("t1".multipoint_18),"t1".phone_20_number,"t1".phone_20_type,"t1".year_8,ST_AsBinary("t1".multiline_14),"t1".json_23,"t1".arrest_9,ST_AsBinary("t1".multipolygon_15),ST_AsBinary("t1".polygon_16),"t1".case_number_6,"t1".updated_on_10,ST_AsBinary("t1".point_13),"t1".id_5,"t1".document_22,ST_AsBinary("t1".location_19_geom),"t1".location_19_address,"t1".primary_type_7,"t1".url_21_url,"t1".url_21_description,ST_AsBinary("t1".line_17) FROM t1 WHERE (to_tsvector('english', coalesce("t1".array_12,'') || ' ' || coalesce("t1".case_number_6,'') || ' ' || coalesce("t1".object_11,'') || ' ' || coalesce("t1".primary_type_7,'') || ' ' || coalesce("t1".url_21_description,'') || ' ' || coalesce("t1".url_21_url,'')) @@ plainto_tsquery('english', ?))""")
     setParams.length should be (1)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("oNe Two"))
@@ -203,14 +203,14 @@ class SqlizerBasicTest extends SqlizerTest {
   test("signed magnitude 10") {
     val soql = "select signed_magnitude_10(year)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (sign(t1.year) * length(floor(abs(t1.year))::text)) FROM t1")
+    sql should be ("""SELECT (sign("t1".year) * length(floor(abs("t1".year))::text)) FROM t1""")
     setParams.length should be (0)
   }
 
   test("signed magnitude linear") {
     val soql = "select signed_magnitude_linear(year, 42)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be("SELECT (case when ? = 1 then floor(t1.year) else sign(t1.year) * floor(abs(t1.year)/? + 1) end) FROM t1")
+    sql should be("""SELECT (case when ? = 1 then floor("t1".year) else sign("t1".year) * floor(abs("t1".year)/? + 1) end) FROM t1""")
     setParams.length should be(2)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(42,42))
@@ -219,56 +219,56 @@ class SqlizerBasicTest extends SqlizerTest {
   test("date_extract_hh") {
     val soql = "select date_extract_hh(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(hour from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(hour from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_dow - day of week") {
     val soql = "select date_extract_dow(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(dow from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(dow from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_woy - week of year") {
     val soql = "select date_extract_woy(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(week from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(week from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_iso_y - iso year") {
     val soql = "select date_extract_iso_y(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(isoyear from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(isoyear from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_y") {
     val soql = "select date_extract_y(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(year from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(year from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_m") {
     val soql = "select date_extract_m(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(month from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(month from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("date_extract_d") {
     val soql = "select date_extract_d(updated_on)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (extract(day from t1.updated_on)::numeric) FROM t1")
+    sql should be ("""SELECT (extract(day from "t1".updated_on)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("to_floating_timestamp") {
     val soql = "select date_trunc_ymd(to_floating_timestamp(:created_at, 'PST'))"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (date_trunc('day', (t1.:created_at at time zone ?))) FROM t1")
+    sql should be ("""SELECT (date_trunc('day', ("t1".:created_at at time zone ?))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("PST"))
   }
@@ -276,7 +276,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("case fn") {
     val soql = "select case(primary_type = 'A', 'X', primary_type = 'B', 'Y')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (case WHEN (t1.primary_type = ?) THEN ? WHEN (t1.primary_type = ?) THEN ? end) FROM t1")
+    sql should be ("""SELECT (case WHEN ("t1".primary_type = ?) THEN ? WHEN ("t1".primary_type = ?) THEN ? end) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("A", "X", "B", "Y"))
   }
@@ -284,7 +284,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("coalesce") {
     val soql = "select coalesce(case_number, primary_type, 'default')"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (coalesce(t1.case_number,t1.primary_type,?)) FROM t1")
+    sql should be ("""SELECT (coalesce("t1".case_number,"t1".primary_type,?)) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("default"))
   }
@@ -300,7 +300,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("simplify multigeometry") {
     val soql = "select simplify(multipolygon, 0.5)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Multi(ST_Simplify(t1.multipolygon, ?)))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Multi(ST_Simplify("t1".multipolygon, ?)))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(0.5))
   }
@@ -308,7 +308,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("simplify geometry") {
     val soql = "select simplify(polygon, 0.5)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Simplify(t1.polygon, ?))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Simplify("t1".polygon, ?))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(0.5))
   }
@@ -316,7 +316,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("simplify multigeometry preserving topology") {
     val soql = "select simplify_preserve_topology(multipolygon, 0.5)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_Multi(ST_SimplifyPreserveTopology(t1.multipolygon, ?)))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_Multi(ST_SimplifyPreserveTopology("t1".multipolygon, ?)))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(0.5))
   }
@@ -324,7 +324,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("simplify geometry preserving topology") {
     val soql = "select simplify_preserve_topology(polygon, 0.5)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_SimplifyPreserveTopology(t1.polygon, ?))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_SimplifyPreserveTopology("t1".polygon, ?))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(0.5))
   }
@@ -332,7 +332,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("geometry snap to grid") {
     val soql = "select snap_to_grid(polygon, 0.5)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((ST_SnapToGrid(t1.polygon, ?))) FROM t1")
+    sql should be ("""SELECT ST_AsBinary((ST_SnapToGrid("t1".polygon, ?))) FROM t1""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(0.5))
   }
@@ -341,10 +341,10 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select curated_region_test(multipolygon, 20)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql.replaceAll("""\s+""", " ") should be ("""SELECT
-                  (case when st_npoints(t1.multipolygon) > ? then 'too complex'
-                        when st_xmin(t1.multipolygon) < -180 or st_xmax(t1.multipolygon) > 180 or st_ymin(t1.multipolygon) < -90 or st_ymax(t1.multipolygon) > 90 then 'out of bounds'
-                        when not st_isvalid(t1.multipolygon) then st_isvalidreason(t1.multipolygon)::text
-                        when (t1.multipolygon) is null then 'empty'
+                  (case when st_npoints("t1".multipolygon) > ? then 'too complex'
+                        when st_xmin("t1".multipolygon) < -180 or st_xmax("t1".multipolygon) > 180 or st_ymin("t1".multipolygon) < -90 or st_ymax("t1".multipolygon) > 90 then 'out of bounds'
+                        when not st_isvalid("t1".multipolygon) then st_isvalidreason("t1".multipolygon)::text
+                        when ("t1".multipolygon) is null then 'empty'
                    end ) FROM t1""".replaceAll("""\s+""", " "))
     setParams.length should be (1)
   }
@@ -354,7 +354,7 @@ class SqlizerBasicTest extends SqlizerTest {
       """SELECT 'aa' as aa WHERE primary_type !='00' |>
         |SELECT aa || 'b' as bb WHERE aa !='11'""".stripMargin
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (\"aa\" || ?) FROM (SELECT ? as \"aa\" FROM t1 WHERE (t1.primary_type != ?)) AS x1 WHERE (\"aa\" != ?)")
+    sql should be ("""SELECT ("aa" || ?) FROM (SELECT ? as "aa" FROM t1 WHERE ("t1".primary_type != ?)) AS "x1" WHERE ("aa" != ?)""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq("b", "aa", "00", "11"))
   }
@@ -365,7 +365,7 @@ class SqlizerBasicTest extends SqlizerTest {
         |SELECT aa || 'b' as bb WHERE aa !='11' |>
         |SELECT bb || 'c' as cc WHERE bb !='22'""".stripMargin
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (\"bb\" || ?) FROM (SELECT (\"aa\" || ?) as \"bb\" FROM (SELECT ? as \"aa\" FROM t1 WHERE (t1.primary_type != ?)) AS x1 WHERE (\"aa\" != ?)) AS x1 WHERE (\"bb\" != ?)")
+    sql should be ("""SELECT ("bb" || ?) FROM (SELECT ("aa" || ?) as "bb" FROM (SELECT ? as "aa" FROM t1 WHERE ("t1".primary_type != ?)) AS "x1" WHERE ("aa" != ?)) AS "x1" WHERE ("bb" != ?)""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq("c", "b", "aa", "00", "11", "22"))
   }
@@ -373,7 +373,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("chained soql only adds ST_AsBinary in the outermost sql") {
     val soql = "select point, object |> select point where within_box(point, 1, 2, 3, 4)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary(\"point\") AS point FROM (SELECT t1.point as \"point\",t1.object as \"object\" FROM t1) AS x1 WHERE (ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ \"point\")")
+    sql should be ("""SELECT ST_AsBinary("point") AS point FROM (SELECT "t1".point as "point","t1".object as "object" FROM t1) AS "x1" WHERE (ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ "point")""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(2, 3, 4, 1).map(BigDecimal(_)))
   }
@@ -381,7 +381,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("chained soql only adds ST_AsBinary - location in the outermost sql") {
     val soql = "select location, object |> select location::point where within_box(location::point, 1, 2, 3, 4)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((\"location_geom\")) AS location_point FROM (SELECT t1.location_geom as \"location_geom\",t1.location_address as \"location_address\",t1.object as \"object\" FROM t1) AS x1 WHERE (ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ (\"location_geom\"))")
+    sql should be ("""SELECT ST_AsBinary(("location_geom")) AS location_point FROM (SELECT "t1".location_geom as "location_geom","t1".location_address as "location_address","t1".object as "object" FROM t1) AS "x1" WHERE (ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ ("location_geom"))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq(2, 3, 4, 1).map(BigDecimal(_)))
   }
@@ -391,14 +391,14 @@ class SqlizerBasicTest extends SqlizerTest {
 
     // search before select, filter, grouping, join
     val ParametricSql(Seq(sqlLeadingSearch), setParamsLeadingSearch) = sqlize(soql, CaseSensitive, useRepsWithId = true, leadingSearch = true)
-    val expectedSqlLeadingSearch = "SELECT \"case_number\",\"primary_type\" FROM (SELECT t1.case_number_6 as \"case_number\",t1.primary_type_7 as \"primary_type\" FROM t1 WHERE (to_tsvector('english', coalesce(t1.array_12,'') || ' ' || coalesce(t1.case_number_6,'') || ' ' || coalesce(t1.object_11,'') || ' ' || coalesce(t1.primary_type_7,'') || ' ' || coalesce(t1.url_21_description,'') || ' ' || coalesce(t1.url_21_url,'')) @@ plainto_tsquery('english', ?))) AS x1 WHERE (to_tsvector('english', coalesce(\"case_number\",'') || ' ' || coalesce(\"primary_type\",'')) @@ plainto_tsquery('english', ?))"
+    val expectedSqlLeadingSearch = """SELECT "case_number","primary_type" FROM (SELECT "t1".case_number_6 as "case_number","t1".primary_type_7 as "primary_type" FROM t1 WHERE (to_tsvector('english', coalesce("t1".array_12,'') || ' ' || coalesce("t1".case_number_6,'') || ' ' || coalesce("t1".object_11,'') || ' ' || coalesce("t1".primary_type_7,'') || ' ' || coalesce("t1".url_21_description,'') || ' ' || coalesce("t1".url_21_url,'')) @@ plainto_tsquery('english', ?))) AS "x1" WHERE (to_tsvector('english', coalesce("case_number",'') || ' ' || coalesce("primary_type",'')) @@ plainto_tsquery('english', ?))"""
     sqlLeadingSearch should be (expectedSqlLeadingSearch)
     val paramsLeadingSearch = setParamsLeadingSearch.map { (setParam) => setParam(None, 0).get }
     paramsLeadingSearch should be(Seq("oNe", "tWo"))
 
     // search after select, filter, grouping, join
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive, useRepsWithId = true, leadingSearch = false)
-    sql should be ("SELECT \"case_number\",\"primary_type\" FROM (SELECT t1.case_number_6 as \"case_number\",t1.primary_type_7 as \"primary_type\" FROM t1 WHERE (to_tsvector('english', coalesce(t1.case_number_6,'') || ' ' || coalesce(t1.primary_type_7,'')) @@ plainto_tsquery('english', ?))) AS x1 WHERE (to_tsvector('english', coalesce(\"case_number\",'') || ' ' || coalesce(\"primary_type\",'')) @@ plainto_tsquery('english', ?))")
+    sql should be ("""SELECT "case_number","primary_type" FROM (SELECT "t1".case_number_6 as "case_number","t1".primary_type_7 as "primary_type" FROM t1 WHERE (to_tsvector('english', coalesce("t1".case_number_6,'') || ' ' || coalesce("t1".primary_type_7,'')) @@ plainto_tsquery('english', ?))) AS "x1" WHERE (to_tsvector('english', coalesce("case_number",'') || ' ' || coalesce("primary_type",'')) @@ plainto_tsquery('english', ?))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be(Seq("oNe", "tWo"))
   }
@@ -408,20 +408,20 @@ class SqlizerBasicTest extends SqlizerTest {
 
     // search before select, filter, grouping, join
     val ParametricSql(Seq(sqlLeadingSearch), setParamsLeadingSearch) = sqlize(soql, CaseSensitive, useRepsWithId = true, leadingSearch = true)
-    sqlLeadingSearch should be ("SELECT \"id\" FROM (SELECT t1.id_5 as \"id\" FROM t1 WHERE (to_tsvector('english', coalesce(t1.array_12,'') || ' ' || coalesce(t1.case_number_6,'') || ' ' || coalesce(t1.object_11,'') || ' ' || coalesce(t1.primary_type_7,'') || ' ' || coalesce(t1.url_21_description,'') || ' ' || coalesce(t1.url_21_url,'')) @@ plainto_tsquery('english', ?))) AS x1 WHERE (false)")
+    sqlLeadingSearch should be ("""SELECT "id" FROM (SELECT "t1".id_5 as "id" FROM t1 WHERE (to_tsvector('english', coalesce("t1".array_12,'') || ' ' || coalesce("t1".case_number_6,'') || ' ' || coalesce("t1".object_11,'') || ' ' || coalesce("t1".primary_type_7,'') || ' ' || coalesce("t1".url_21_description,'') || ' ' || coalesce("t1".url_21_url,'')) @@ plainto_tsquery('english', ?))) AS "x1" WHERE (false)""")
     val paramsLeadingSearch = setParamsLeadingSearch.map { (setParam) => setParam(None, 0).get }
     paramsLeadingSearch should be(Seq("oNe"))
 
     // search after select, filter, grouping, join
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive, useRepsWithId = true, leadingSearch = false)
-    sql should be ("SELECT \"id\" FROM (SELECT t1.id_5 as \"id\" FROM t1 WHERE (false)) AS x1 WHERE (false)")
+    sql should be ("""SELECT "id" FROM (SELECT "t1".id_5 as "id" FROM t1 WHERE (false)) AS "x1" WHERE (false)""")
     setParams.length should be (0)
   }
 
   test("group by literals with constants removed") {
     val soql = "select id, 'stRing' as a, 5 as b, 2*3 as c group by id, a, b, c"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.id,e'stRing',5,(2 * 3) FROM t1 GROUP BY t1.id")
+    sql should be ("""SELECT "t1".id,e'stRing',5,(2 * 3) FROM t1 GROUP BY "t1".id""")
     setParams.length should be (0)
   }
 
@@ -438,7 +438,7 @@ class SqlizerBasicTest extends SqlizerTest {
   test("distinct") {
     val soql = "select distinct case_number, primary_type"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT DISTINCT t1.case_number,t1.primary_type FROM t1")
+    sql should be ("""SELECT DISTINCT "t1".case_number,"t1".primary_type FROM t1""")
     setParams.length should be (0)
   }
 
@@ -448,7 +448,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val encodedRowId = rep.apply(SoQLID(rowId))
     val soql = s"select id where :id = '$encodedRowId'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.id FROM t1 WHERE (":id_1" = (?))""")
+    sql should be ("""SELECT "t1".id FROM t1 WHERE (":id_1" = (?))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(rowId))
   }
@@ -457,7 +457,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select avg(year) over(partition by primary_type, year)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("SELECT (avg(t1.year) over( partition by t1.primary_type,t1.year)) FROM t1")
+    sql should be ("""SELECT (avg("t1".year) over( partition by "t1".primary_type,"t1".year)) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -465,7 +465,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select avg(year) over()"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("SELECT (avg(t1.year) over()) FROM t1")
+    sql should be ("""SELECT (avg("t1".year) over()) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -473,7 +473,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select row_number() over(partition by primary_type, year order by primary_type, year) as rn |> select * where rn < 2"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("""SELECT "rn" FROM (SELECT (row_number() over( partition by t1.primary_type,t1.year order by t1.primary_type nulls last,t1.year nulls last)) as "rn" FROM t1) AS x1 WHERE ("rn" < ?)""")
+    sql should be ("""SELECT "rn" FROM (SELECT (row_number() over( partition by "t1".primary_type,"t1".year order by "t1".primary_type nulls last,"t1".year nulls last)) as "rn" FROM t1) AS "x1" WHERE ("rn" < ?)""")
     params should be(Seq(2))
   }
 
@@ -481,7 +481,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select rank() over(order by year)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("SELECT (rank() over( order by t1.year nulls last)) FROM t1")
+    sql should be ("""SELECT (rank() over( order by "t1".year nulls last)) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -489,7 +489,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select avg(year) over(partition by primary_type, year ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("SELECT (avg(t1.year) over( partition by t1.primary_type,t1.year ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)) FROM t1")
+    sql should be ("""SELECT (avg("t1".year) over( partition by "t1".primary_type,"t1".year ROWS BETWEEN 6 PRECEDING AND CURRENT ROW)) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -497,7 +497,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val soql = "select json.foo"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     val params = setParams.map { (setParam) => setParam(None, 0).get }
-    sql should be ("SELECT (t1.json -> ?) FROM t1")
+    sql should be ("SELECT (\"t1\".json -> ?) FROM t1")
     params should be (Seq("foo"))
 
   }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -8,49 +8,49 @@ class SqlizerJoinTest  extends SqlizerTest {
   test("join wo alias") {
     val soql = "select case_number, primary_type, @type.description join @type on primary_type = @type.primary_type"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.case_number,t1.primary_type,t2.description FROM t1 JOIN t2 ON (t1.primary_type = t2.primary_type)")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,"t2".description FROM t1 JOIN t2 ON ("t1".primary_type = "t2".primary_type)""")
     setParams.length should be (0)
   }
 
   test("join with alias") {
     val soql = "select case_number, primary_type, @y.avg_temperature join @year as y on @y.year = year"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.case_number,t1.primary_type,_y.avg_temperature FROM t1 JOIN t3 as _y ON (_y.year = t1.year)""")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,"_y".avg_temperature FROM t1 JOIN t3 as "_y" ON ("_y".year = "t1".year)""")
     setParams.length should be (0)
   }
 
   test("single row joined to table on true moves the first join into from") {
     val soql = "select 'bleh' from @single_row join @year as y on true"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ? FROM t3 as _y")
+    sql should be ("""SELECT ? FROM t3 as "_y"""")
     psql.paramsAsStrings should be (Seq("bleh"))
   }
 
   test("single row joined to subquery on true moves the first join into from") {
     val soql = "select 'bleh' from @single_row join (select * from @year) as y on true"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT ? FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) as _y""")
+    sql should be ("""SELECT ? FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) as "_y"""")
     psql.paramsAsStrings should be (Seq("bleh"))
   }
 
   test("single row joined to subquery on true moves the first join into from, with parameters in the subquery") {
     val soql = "select 'bleh' from @single_row join (select *, 'a' from @year) as y on true"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT ? FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature",? as "a" FROM t3) as _y""")
+    sql should be ("""SELECT ? FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature",? as "a" FROM t3) as "_y"""")
     psql.paramsAsStrings should be (Seq("bleh", "a"))
   }
 
   test("single row join to table on anything other than true does generate a from clause") {
     val soql = "select 'bleh' from @single_row join @year as y on false"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ? FROM single_row JOIN t3 as _y ON ?")
+    sql should be ("""SELECT ? FROM single_row JOIN t3 as "_y" ON ?""")
     psql.paramsAsStrings should be (Seq("bleh", "false"))
   }
 
   test("single row join to subquery on anything other than true does generate a from clause") {
     val soql = "select 'bleh' from @single_row join (select *, 'a' from @year) as y on false"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT ? FROM single_row JOIN (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature",? as "a" FROM t3) as _y ON ?""")
+    sql should be ("""SELECT ? FROM single_row JOIN (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature",? as "a" FROM t3) as "_y" ON ?""")
     psql.paramsAsStrings should be (Seq("bleh", "a", "false"))
   }
 
@@ -64,21 +64,21 @@ class SqlizerJoinTest  extends SqlizerTest {
   test("join to single_row in subselect") {
     val soql = "select 'bleh' join (select 1, 2, 3 from @single_row) as vars on true"
     val psql@ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ? FROM t1 JOIN (SELECT ? as \"_1\",? as \"_2\",? as \"_3\") as _vars ON ?")
+    sql should be ("""SELECT ? FROM t1 JOIN (SELECT ? as "_1",? as "_2",? as "_3") as "_vars" ON ?""")
     psql.paramsAsStrings should be (Seq("bleh", "1", "2", "3", "true"))
   }
 
   test("join and chain") {
     val soql = "select case_number, primary_type, @y.avg_temperature join @year as y on @y.year = year |> select count(*)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT (count(*)::numeric) FROM (SELECT t1.case_number as "case_number",t1.primary_type as "primary_type",_y.avg_temperature as "avg_temperature" FROM t1 JOIN t3 as _y ON (_y.year = t1.year)) AS x1""")
+    sql should be ("""SELECT (count(*)::numeric) FROM (SELECT "t1".case_number as "case_number","t1".primary_type as "primary_type","_y".avg_temperature as "avg_temperature" FROM t1 JOIN t3 as "_y" ON ("_y".year = "t1".year)) AS "x1"""")
     setParams.length should be (0)
   }
 
   test("group and then join with qualified fields from join") {
     val soql = "select primary_type, count(case_number), max(year) as year group by primary_type |> select primary_type, year, @y.avg_temperature join @year as y on @y.year = year and year = 2000"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT x1."primary_type",x1."year",_y.avg_temperature FROM (SELECT t1.primary_type as "primary_type",((count(t1.case_number))::numeric) as "count_case_number",(max(t1.year)) as "year" FROM t1 GROUP BY t1.primary_type) AS x1 JOIN t3 as _y ON ((_y.year = x1."year") and (x1."year" = ?))""")
+    sql should be ("""SELECT "x1"."primary_type","x1"."year","_y".avg_temperature FROM (SELECT "t1".primary_type as "primary_type",((count("t1".case_number))::numeric) as "count_case_number",(max("t1".year)) as "year" FROM t1 GROUP BY "t1".primary_type) AS "x1" JOIN t3 as "_y" ON (("_y".year = "x1"."year") and ("x1"."year" = ?))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(2000))
   }
@@ -86,21 +86,21 @@ class SqlizerJoinTest  extends SqlizerTest {
   test("join with sub-query - select *") {
     val soql = "select case_number, primary_type, @y.year join (SELECT year FROM @year) as y on @y.year = year"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.case_number,t1.primary_type,_y."year" FROM t1 JOIN (SELECT t3.year as "year" FROM t3) as _y ON (_y."year" = t1.year)""")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,"_y"."year" FROM t1 JOIN (SELECT "t3".year as "year" FROM t3) as "_y" ON ("_y"."year" = "t1".year)""")
     setParams.length should be (0)
   }
 
   test("join with sub-query - select columns") {
     val soql = "select case_number, primary_type, @y.year, @y.avg_temperature join (SELECT * FROM @year) as y on @y.year = year"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.case_number,t1.primary_type,_y."year",_y."avg_temperature" FROM t1 JOIN (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) as _y ON (_y."year" = t1.year)""")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,"_y"."year","_y"."avg_temperature" FROM t1 JOIN (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) as "_y" ON ("_y"."year" = "t1".year)""")
     setParams.length should be (0)
   }
 
   test("join with chained sub-query - select columns") {
     val soql = "select case_number, primary_type, @y.year, @y.avg_temperature join (SELECT * FROM @year |> SELECT year, avg_temperature WHERE avg_temperature > 30) as y on @y.year = year and year = 2000"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.case_number,t1.primary_type,_y."year",_y."avg_temperature" FROM t1 JOIN (SELECT "year" as "year","avg_temperature" as "avg_temperature" FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1 WHERE ("avg_temperature" > ?)) as _y ON ((_y."year" = t1.year) and (t1.year = ?))""")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,"_y"."year","_y"."avg_temperature" FROM t1 JOIN (SELECT "year" as "year","avg_temperature" as "avg_temperature" FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1" WHERE ("avg_temperature" > ?)) as "_y" ON (("_y"."year" = "t1".year) and ("t1".year = ?))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(30, 2000).map(BigDecimal(_)))
   }
@@ -108,20 +108,20 @@ class SqlizerJoinTest  extends SqlizerTest {
   test("join and date extract") {
     val soql = "select case_number, primary_type, date_extract_woy(@type.registered) join @type on primary_type = @type.primary_type"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.case_number,t1.primary_type,(extract(week from t2.registered)::numeric) FROM t1 JOIN t2 ON (t1.primary_type = t2.primary_type)")
+    sql should be ("""SELECT "t1".case_number,"t1".primary_type,(extract(week from "t2".registered)::numeric) FROM t1 JOIN t2 ON ("t1".primary_type = "t2".primary_type)""")
     setParams.length should be (0)
   }
 
   test("chained primary table join with chained sub-query - select columns") {
     val soql = "select case_number, primary_type |> select primary_type, count(*) as total group by primary_type |> select primary_type, total |>  select primary_type, total, @y.year, @y.avg_temperature join (SELECT * FROM @year |> SELECT year, avg_temperature WHERE avg_temperature > 30) as y on @y.year = total and total = 2000"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT x1."primary_type",x1."total",_y."year",_y."avg_temperature" FROM (SELECT "primary_type" as "primary_type","total" as "total" FROM (SELECT "primary_type" as "primary_type",(count(*)::numeric) as "total" FROM (SELECT t1.case_number as "case_number",t1.primary_type as "primary_type" FROM t1) AS x1 GROUP BY "primary_type") AS x1) AS x1 JOIN (SELECT x1."year" as "year",x1."avg_temperature" as "avg_temperature" FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1 WHERE (x1."avg_temperature" > ?)) as _y ON ((_y."year" = x1."total") and (x1."total" = ?))""")
+    sql should be ("""SELECT "x1"."primary_type","x1"."total","_y"."year","_y"."avg_temperature" FROM (SELECT "primary_type" as "primary_type","total" as "total" FROM (SELECT "primary_type" as "primary_type",(count(*)::numeric) as "total" FROM (SELECT "t1".case_number as "case_number","t1".primary_type as "primary_type" FROM t1) AS "x1" GROUP BY "primary_type") AS "x1") AS "x1" JOIN (SELECT "x1"."year" as "year","x1"."avg_temperature" as "avg_temperature" FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1" WHERE ("x1"."avg_temperature" > ?)) as "_y" ON (("_y"."year" = "x1"."total") and ("x1"."total" = ?))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(30, 2000).map(BigDecimal(_)))
 
     val soqlChainSelectMax = soql + " |> select max(year)"
     val ParametricSql(Seq(sqlChainSelectMax), setParamsChainSelectMax) = sqlize(soqlChainSelectMax, CaseSensitive)
-    sqlChainSelectMax should be ("""SELECT (max("year")) FROM (SELECT x1."primary_type" as "primary_type",x1."total" as "total",_y."year" as "year",_y."avg_temperature" as "avg_temperature" FROM (SELECT "primary_type" as "primary_type","total" as "total" FROM (SELECT "primary_type" as "primary_type",(count(*)::numeric) as "total" FROM (SELECT t1.case_number as "case_number",t1.primary_type as "primary_type" FROM t1) AS x1 GROUP BY "primary_type") AS x1) AS x1 JOIN (SELECT x1."year" as "year",x1."avg_temperature" as "avg_temperature" FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1 WHERE (x1."avg_temperature" > ?)) as _y ON ((_y."year" = x1."total") and (x1."total" = ?))) AS x1""")
+    sqlChainSelectMax should be ("""SELECT (max("year")) FROM (SELECT "x1"."primary_type" as "primary_type","x1"."total" as "total","_y"."year" as "year","_y"."avg_temperature" as "avg_temperature" FROM (SELECT "primary_type" as "primary_type","total" as "total" FROM (SELECT "primary_type" as "primary_type",(count(*)::numeric) as "total" FROM (SELECT "t1".case_number as "case_number","t1".primary_type as "primary_type" FROM t1) AS "x1" GROUP BY "primary_type") AS "x1") AS "x1" JOIN (SELECT "x1"."year" as "year","x1"."avg_temperature" as "avg_temperature" FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1" WHERE ("x1"."avg_temperature" > ?)) as "_y" ON (("_y"."year" = "x1"."total") and ("x1"."total" = ?))) AS "x1"""")
     val paramsChainSelectMax = setParams.map { (setParam) => setParam(None, 0).get }
     paramsChainSelectMax should be (params)
   }
@@ -138,15 +138,15 @@ class SqlizerJoinTest  extends SqlizerTest {
          """.stripMargin
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
 
-    val expectedSql = """SELECT t1.case_number FROM t1
+    val expectedSql = """SELECT "t1".case_number FROM t1
       |     JOIN
       |  (SELECT (coalesce((max("avg_temperature")),?)) as "coalesce_max_avg_temperature_1","year" as "year"
-      |     FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1
-      |    WHERE ("avg_temperature" < ?) GROUP BY "year") as _j1 ON (t1.year = _j1."year")
+      |     FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1"
+      |    WHERE ("avg_temperature" < ?) GROUP BY "year") as "_j1" ON ("t1".year = "_j1"."year")
       |     JOIN
       |  (SELECT (coalesce((sum("avg_temperature")),?)) as "coalesce_sum_avg_temperature_3","year" as "year"
-      |     FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1
-      |    WHERE ("avg_temperature" < ?) GROUP BY "year") as _j2 ON (t1.year = _j2."year")""".stripMargin
+      |     FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1"
+      |    WHERE ("avg_temperature" < ?) GROUP BY "year") as "_j2" ON ("t1".year = "_j2"."year")""".stripMargin
 
     collapseSpace(sql) should be (collapseSpace(expectedSql))
     val params = setParams.map { (setParam) => setParam(None, 0).get }
@@ -165,15 +165,15 @@ class SqlizerJoinTest  extends SqlizerTest {
          """
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
 
-    val expectedSql = """SELECT "case_number",? FROM (SELECT t1.case_number as "case_number" FROM t1
+    val expectedSql = """SELECT "case_number",? FROM (SELECT "t1".case_number as "case_number" FROM t1
                                   JOIN
                                        (SELECT (coalesce((max("avg_temperature")),?)) as "coalesce_max_avg_temperature_1","year" as "year"
-                                          FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1
-                                         WHERE ("avg_temperature" < ?) GROUP BY "year") as _j1 ON (t1.year = _j1."year")
+                                          FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1"
+                                         WHERE ("avg_temperature" < ?) GROUP BY "year") as "_j1" ON ("t1".year = "_j1"."year")
                                   JOIN
                                        (SELECT (coalesce((sum("avg_temperature")),?)) as "coalesce_sum_avg_temperature_3","year" as "year"
-                                          FROM (SELECT t3.year as "year",t3.avg_temperature as "avg_temperature" FROM t3) AS x1
-                                         WHERE ("avg_temperature" < ?) GROUP BY "year") as _j2 ON (t1.year = _j2."year")) AS x1 WHERE (? = ?)"""
+                                          FROM (SELECT "t3".year as "year","t3".avg_temperature as "avg_temperature" FROM t3) AS "x1"
+                                         WHERE ("avg_temperature" < ?) GROUP BY "year") as "_j2" ON ("t1".year = "_j2"."year")) AS "x1" WHERE (? = ?)"""
 
     collapseSpace(sql) should be (collapseSpace(expectedSql))
 
@@ -183,35 +183,35 @@ class SqlizerJoinTest  extends SqlizerTest {
 
   test("this alias") {
     val soql = "SELECT @t.id FROM @this as t"
-    val expected = "SELECT _t.id FROM t1 as _t"
+    val expected = """SELECT "_t".id FROM t1 as "_t""""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
 
   test("this alias in chained soql") {
     val soql = "select id |> select @t.id from @this as t"
-    val expected = """SELECT _t."id" FROM (SELECT t1.id as "id" FROM t1) as _t"""
+    val expected = """SELECT "_t"."id" FROM (SELECT "t1".id as "id" FROM t1) as "_t""""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
 
   test("join chained soql and multiple this's") {
     val soql = "select @t.id from @this as t join (select name from @cat |> select @tc.name from @this as tc ) as c on true"
-    val expected = """SELECT _t.id FROM t1 as _t JOIN (SELECT _tc."name" as "name" FROM (SELECT "name_45" as "name" FROM t11) as _tc) as _c ON ?"""
+    val expected = """SELECT "_t".id FROM t1 as "_t" JOIN (SELECT "_tc"."name" as "name" FROM (SELECT "name_45" as "name" FROM t11) as "_tc") as "_c" ON ?"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
 
   test("lateral join and this") {
     val soql = "select @t.id from @this as t join lateral (select name, @t.id from @cat) as c on true"
-    val expected = """SELECT _t.id FROM t1 as _t JOIN LATERAL (SELECT "name_45" as "name",_t.id as "id" FROM t11) as _c ON ?"""
+    val expected = """SELECT "_t".id FROM t1 as "_t" JOIN LATERAL (SELECT "name_45" as "name","_t".id as "id" FROM t11) as "_c" ON ?"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
 
   test("lateral join chained soql and this") {
     val soql = "select @t.id from @this as t join @dog as d on true join lateral (select name from @cat |> select name, @d.dog) as c on true"
-    val expected = """SELECT _t.id FROM t1 as _t JOIN t12 as _d ON ?  JOIN LATERAL (SELECT "name" as "name",_d."dog_58" as "dog" FROM (SELECT "name_45" as "name" FROM t11) AS x1) as _c ON ?"""
+    val expected = """SELECT "_t".id FROM t1 as "_t" JOIN t12 as "_d" ON ?  JOIN LATERAL (SELECT "name" as "name","_d"."dog_58" as "dog" FROM (SELECT "name_45" as "name" FROM t11) AS "x1") as "_c" ON ?"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
@@ -221,7 +221,7 @@ class SqlizerJoinTest  extends SqlizerTest {
       """SELECT @t.primary_type FROM @this as t UNION
          (SELECT breed, cat FROM @cat |> SELECT @c.cat FROM @this as c) UNION
          (SELECT breed, dog FROM @dog |> SELECT @d.dog FROM @this as d)"""
-    val expected = """SELECT _t.primary_type FROM t1 as _t UNION (SELECT _c."cat" FROM (SELECT "breed_46" as "breed","cat_48" as "cat" FROM t11) as _c) UNION (SELECT _d."dog" FROM (SELECT "breed_56" as "breed","dog_58" as "dog" FROM t12) as _d)"""
+    val expected = """SELECT "_t".primary_type FROM t1 as "_t" UNION (SELECT "_c"."cat" FROM (SELECT "breed_46" as "breed","cat_48" as "cat" FROM t11) as "_c") UNION (SELECT "_d"."dog" FROM (SELECT "breed_56" as "breed","dog_58" as "dog" FROM t12) as "_d")"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
@@ -233,14 +233,14 @@ class SqlizerJoinTest  extends SqlizerTest {
          SELECT name FROM @dog UNioN aLL
          SELECT name FROM @bird UnioN
          SELECT name FROM @fish"""
-    val expected = """SELECT _t.primary_type FROM t1 as _t EXCEPT SELECT "name_45" FROM t11 INTERSECT SELECT "name_55" FROM t12 UNION ALL SELECT "name_65" FROM t13 UNION SELECT "name_65" FROM t14"""
+    val expected = """SELECT "_t".primary_type FROM t1 as "_t" EXCEPT SELECT "name_45" FROM t11 INTERSECT SELECT "name_55" FROM t12 UNION ALL SELECT "name_65" FROM t13 UNION SELECT "name_65" FROM t14"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
 
   test("generate ':id' in system columns in the right side of a chained soql with this alias and join") {
     val soql = "SELECT @t.:id FROM @this as t |> SELECT @t2.:id, @d.:id as id2 FROM @this as t2 JOIN @dog as d ON true"
-    val expected = """SELECT _t2.":id",_d.":id_51" FROM (SELECT _t.":id_1" as ":id" FROM t1 as _t) as _t2 JOIN t12 as _d ON ?"""
+    val expected = """SELECT "_t2".":id","_d".":id_51" FROM (SELECT "_t".":id_1" as ":id" FROM t1 as "_t") as "_t2" JOIN t12 as "_d" ON ?"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive, useRepsWithId = true)
     println(sql)
     sql should be (expected)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJsonbTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJsonbTest.scala
@@ -8,7 +8,7 @@ class SqlizerJsonbTest extends SqlizerTest {
   test("document jsonb field optimized eq query should use operator @>") {
     val soql = "SELECT document WHERE document.filename = 'document.txt'"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT t1.document FROM t1 WHERE (t1.document @> ('{"filename":"' || ? || '"}')::jsonb)""")
+    sql should be ("""SELECT "t1".document FROM t1 WHERE ("t1".document @> ('{"filename":"' || ? || '"}')::jsonb)""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("document.txt"))
   }
@@ -16,7 +16,7 @@ class SqlizerJsonbTest extends SqlizerTest {
   test("document jsonb field non-optimized eq query should use operator ->>") {
     val soql = "SELECT document WHERE document.file_id = case_number"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.document FROM t1 WHERE ((t1.document->>'file_id') = t1.case_number)")
+    sql should be ("""SELECT "t1".document FROM t1 WHERE (("t1".document->>'file_id') = "t1".case_number)""")
     setParams.isEmpty should be (true)
   }
 }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerLocationTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerLocationTest.scala
@@ -8,28 +8,28 @@ class SqlizerLocationTest extends SqlizerTest {
   test("location latitude") {
     val soql = "select location_latitude(location)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_Y(t1.location_geom)::numeric) FROM t1")
+    sql should be ("""SELECT (ST_Y("t1".location_geom)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("location longitude") {
     val soql = "select location_longitude(location)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_X(t1.location_geom)::numeric) FROM t1")
+    sql should be ("""SELECT (ST_X("t1".location_geom)::numeric) FROM t1""")
     setParams.length should be (0)
   }
 
   test("location human_address") {
     val soql = "select location_human_address(location)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (t1.location_address) FROM t1")
+    sql should be ("""SELECT ("t1".location_address) FROM t1""")
     setParams.length should be (0)
   }
 
   test("location point") {
     val soql = "select location::point"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT ST_AsBinary((t1.location_geom)) FROM t1")
+    sql should be ("""SELECT ST_AsBinary(("t1".location_geom)) FROM t1""")
     setParams.length should be (0)
   }
 
@@ -37,8 +37,8 @@ class SqlizerLocationTest extends SqlizerTest {
     val soql = "select case_number where within_circle(location, 1.0, 2.0, 30)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be (
-      """SELECT t1.case_number FROM t1
-        | WHERE ((ST_within((t1.location_geom), ST_Buffer(ST_MakePoint(?, ?)::geography, ?)::geometry)))"""
+      """SELECT "t1".case_number FROM t1
+        | WHERE ((ST_within(("t1".location_geom), ST_Buffer(ST_MakePoint(?, ?)::geography, ?)::geometry)))"""
         .stripMargin.replaceAll("\n", ""))
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(2.0, 1.0, 30d).map(BigDecimal.valueOf(_)))
@@ -48,8 +48,8 @@ class SqlizerLocationTest extends SqlizerTest {
     val soql = "select case_number where within_box(location, 1.0, 2.0, 3.0, 4.0)"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be (
-      """SELECT t1.case_number FROM t1
-        | WHERE ((ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ (t1.location_geom)))"""
+      """SELECT "t1".case_number FROM t1
+        | WHERE ((ST_MakeEnvelope(?, ?, ?, ?, 4326) ~ ("t1".location_geom)))"""
         .stripMargin.replaceAll("\n", ""))
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(2.0, 3.0, 4.0, 1.0).map(BigDecimal.valueOf(_)))
@@ -58,7 +58,7 @@ class SqlizerLocationTest extends SqlizerTest {
   test("subcolumn subscript converted") {
     val soql = """SELECT location.longitude as longitude WHERE location.latitude = 1.1 order by longitude"""
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (ST_X(t1.location_geom)::numeric) FROM t1 WHERE ((ST_Y(t1.location_geom)::numeric) = ?) ORDER BY (ST_X(t1.location_geom)::numeric) nulls last")
+    sql should be ("""SELECT (ST_X("t1".location_geom)::numeric) FROM t1 WHERE ((ST_Y("t1".location_geom)::numeric) = ?) ORDER BY (ST_X("t1".location_geom)::numeric) nulls last""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq(BigDecimal.valueOf(1.1)))
   }
@@ -79,7 +79,7 @@ class SqlizerLocationTest extends SqlizerTest {
   test("group by geometry no longer generates ST_AsBinary on geometry column in group by") {
     val soql = """SELECT snap_to_grid(polygon, 2) as snapped, count(*) GROUP BY snapped"""
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("""SELECT ST_AsBinary((ST_SnapToGrid(t1.polygon, 2))),(count(*)::numeric) FROM t1 GROUP BY (ST_SnapToGrid(t1.polygon, 2))""")
+    sql should be ("""SELECT ST_AsBinary((ST_SnapToGrid("t1".polygon, 2))),(count(*)::numeric) FROM t1 GROUP BY (ST_SnapToGrid("t1".polygon, 2))""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     setParams.length should be (0)
   }

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerUrlTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerUrlTest.scala
@@ -8,7 +8,7 @@ class SqlizerUrlTest extends SqlizerTest {
   test("url subcolumn") {
     val soql = "SELECT url.url as url_url WHERE url.description = 'Home Site' order by url_url"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT (t1.url_url) FROM t1 WHERE ((t1.url_description) = ?) ORDER BY (t1.url_url) nulls last")
+    sql should be ("""SELECT ("t1".url_url) FROM t1 WHERE (("t1".url_description) = ?) ORDER BY ("t1".url_url) nulls last""")
     val params = setParams.map { (setParam) => setParam(None, 0).get }
     params should be (Seq("Home Site"))
   }
@@ -24,20 +24,20 @@ class SqlizerUrlTest extends SqlizerTest {
   test("url group") {
     val soql = "SELECT url, count(*) GROUP BY url"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.url_url,t1.url_description,(count(*)::numeric) FROM t1 GROUP BY t1.url_url,t1.url_description")
+    sql should be ("""SELECT "t1".url_url,"t1".url_description,(count(*)::numeric) FROM t1 GROUP BY "t1".url_url,"t1".url_description""")
     setParams should be (Seq.empty)
   }
 
   test("url order") {
     val soql = "SELECT url ORDER BY url"
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
-    sql should be ("SELECT t1.url_url,t1.url_description FROM t1 ORDER BY t1.url_url nulls last,t1.url_description nulls last")
+    sql should be ("""SELECT "t1".url_url,"t1".url_description FROM t1 ORDER BY "t1".url_url nulls last,"t1".url_description nulls last""")
     setParams should be (Seq.empty)
   }
 
   test("url count") {
     val soql = "SELECT count(url)"
-    val expected = "SELECT ((count((coalesce((t1.url_url),(t1.url_description)))))::numeric) FROM t1"
+    val expected = """SELECT ((count((coalesce(("t1".url_url),("t1".url_description)))))::numeric) FROM t1"""
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be(expected)
     setParams should be(Seq.empty)
@@ -45,7 +45,7 @@ class SqlizerUrlTest extends SqlizerTest {
 
   test("url.url count") {
     val soql = "SELECT count(url.url)"
-    val expected = "SELECT ((count((t1.url_url)))::numeric) FROM t1"
+    val expected = """SELECT ((count(("t1".url_url)))::numeric) FROM t1"""
     val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
     sql should be(expected)
     setParams should be(Seq.empty)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.4.1"
+    val soqlStdlib = "3.5.0"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.10"
     val typesafeScalaLogging = "3.9.2"

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
@@ -200,20 +200,20 @@ class SoQLUnionTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBa
   }
 
   test("Sqlize - union no table alias") {
-    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM (SELECT t1.u_name_4 as "name" FROM t1 WHERE (? != ?) UNION SELECT t2.u_name_4 as "name" FROM t2 WHERE (t2.u_year_6 = ?)) AS x1 ORDER BY "name" nulls last""",
+    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 WHERE (? != ?) UNION SELECT "t2".u_name_4 as "name" FROM t2 WHERE ("t2".u_year_6 = ?)) AS "x1" ORDER BY "name" nulls last""",
       Seq(3, 2, 1))
   }
 
   test("Sqlize - union table alias") {
-    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM (SELECT t1.u_name_4 as "name" FROM t1 UNION SELECT _d1.u_name_4 as "name" FROM t2 as _d1 GROUP BY _d1.u_name_4) AS x1 ORDER BY "name" nulls last""")
+    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 UNION SELECT "_d1".u_name_4 as "name" FROM t2 as "_d1" GROUP BY "_d1".u_name_4) AS "x1" ORDER BY "name" nulls last""")
   }
 
   test("Sqlize - urls") {
-    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM (SELECT t1.u_url_8_url as "url_url",t1.u_url_8_description as "url_description",t1.u_cat_7 as "cat" FROM t1 WHERE (t1.u_url_8_url is not null or t1.u_url_8_description is not null) UNION SELECT t2.u_url_8_url as "url_url",t2.u_url_8_description as "url_description",t2.u_dog_7 as "dog" FROM t2 WHERE (t2.u_url_8_url is not null or t2.u_url_8_description is not null)) AS x1 ORDER BY "cat" nulls last""")
+    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM (SELECT "t1".u_url_8_url as "url_url","t1".u_url_8_description as "url_description","t1".u_cat_7 as "cat" FROM t1 WHERE ("t1".u_url_8_url is not null or "t1".u_url_8_description is not null) UNION SELECT "t2".u_url_8_url as "url_url","t2".u_url_8_description as "url_description","t2".u_dog_7 as "dog" FROM t2 WHERE ("t2".u_url_8_url is not null or "t2".u_url_8_description is not null)) AS "x1" ORDER BY "cat" nulls last""")
   }
 
   test("Sqlize - mixed and nested") {
-    sqlizeTest(soqls("mixed and nested"), """SELECT "name","breed","b3","bird" FROM (SELECT t1.u_name_4 as "name",_jd1."breed" as "breed",_jd1."dog" as "dog",t2.u_breed_5 as "b2",_jb1."breed" as "b3",_jb1."bird" as "bird" FROM t1 JOIN (SELECT t2.u_breed_5 as "breed",t2.u_dog_7 as "dog",t2.u_year_6 as "year" FROM t2) as _jd1 ON (_jd1."year" = t1.u_year_6)  JOIN t2 ON (t2.u_year_6 = t1.u_year_6)  JOIN (SELECT t3.u_breed_5 as "breed",t3.u_bird_8 as "bird",t3.u_year_6 as "year" FROM t3 WHERE ((t3.u_year_6 = ?) and ((t3.u_year_6 + ?) = ?)) UNION (SELECT t4.u_breed_5 as "breed",t4.u_fish_8 as "fish",? as "_1" FROM t4 WHERE (t4.u_year_6 = ?) GROUP BY t4.u_breed_5,t4.u_fish_8 UNION SELECT _jb1.u_breed_5 as "breed",t3.u_bird_8 as "bird",? as "_1" FROM t3 JOIN t3 as _jb1 ON (t3.u_year_6 = _jb1.u_year_6) WHERE (t3.u_year_6 = ?))) as _jb1 ON (_jb1."year" = t1.u_year_6) WHERE (t1.u_year_6 = ?)) AS x1 ORDER BY "b3" nulls last,"bird" nulls last LIMIT 5""",
+    sqlizeTest(soqls("mixed and nested"), """SELECT "name","breed","b3","bird" FROM (SELECT "t1".u_name_4 as "name","_jd1"."breed" as "breed","_jd1"."dog" as "dog","t2".u_breed_5 as "b2","_jb1"."breed" as "b3","_jb1"."bird" as "bird" FROM t1 JOIN (SELECT "t2".u_breed_5 as "breed","t2".u_dog_7 as "dog","t2".u_year_6 as "year" FROM t2) as "_jd1" ON ("_jd1"."year" = "t1".u_year_6)  JOIN t2 ON ("t2".u_year_6 = "t1".u_year_6)  JOIN (SELECT "t3".u_breed_5 as "breed","t3".u_bird_8 as "bird","t3".u_year_6 as "year" FROM t3 WHERE (("t3".u_year_6 = ?) and (("t3".u_year_6 + ?) = ?)) UNION (SELECT "t4".u_breed_5 as "breed","t4".u_fish_8 as "fish",? as "_1" FROM t4 WHERE ("t4".u_year_6 = ?) GROUP BY "t4".u_breed_5,"t4".u_fish_8 UNION SELECT "_jb1".u_breed_5 as "breed","t3".u_bird_8 as "bird",? as "_1" FROM t3 JOIN t3 as "_jb1" ON ("t3".u_year_6 = "_jb1".u_year_6) WHERE ("t3".u_year_6 = ?))) as "_jb1" ON ("_jb1"."year" = "t1".u_year_6) WHERE ("t1".u_year_6 = ?)) AS "x1" ORDER BY "b3" nulls last,"bird" nulls last LIMIT 5""",
       Seq(1, 1, 2, 1, 2, 1, 3, 1))
   }
 


### PR DESCRIPTION
They can contain "-" now, so ensure we quote all aliases always, as the
_-prefix is no longer sufficient.

Most of this is just updating the tests to expect them.