### PR TITLE
EN-47308: Always fully-parenthesize select merge operations

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -126,8 +126,7 @@ object BinarySoQLAnalysisSqlizer extends Sqlizer[(BinaryTree[SoQLAnalysis[UserCo
         val setParamsAcc = lpsql.setParams ++ rpsql.setParams
         val sqlQueryOp = toSqlQueryOp(op)
         val unionSql = lpsql.sql.zip(rpsql.sql).map { case (ls, rs) =>
-          if (r.asLeaf.nonEmpty) s"${ls} $sqlQueryOp ${rs}"
-          else s"${ls} $sqlQueryOp (${rs})"
+          s"(${ls}) $sqlQueryOp (${rs})"
         }
         (ParametricSql(unionSql, setParamsAcc), lpcts + rpcts)
       case Leaf(analysis) =>

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -221,7 +221,7 @@ class SqlizerJoinTest  extends SqlizerTest {
       """SELECT @t.primary_type FROM @this as t UNION
          (SELECT breed, cat FROM @cat |> SELECT @c.cat FROM @this as c) UNION
          (SELECT breed, dog FROM @dog |> SELECT @d.dog FROM @this as d)"""
-    val expected = """SELECT "_t".primary_type FROM t1 as "_t" UNION (SELECT "_c"."cat" FROM (SELECT "breed_46" as "breed","cat_48" as "cat" FROM t11) as "_c") UNION (SELECT "_d"."dog" FROM (SELECT "breed_56" as "breed","dog_58" as "dog" FROM t12) as "_d")"""
+    val expected = """((SELECT "_t".primary_type FROM t1 as "_t") UNION (SELECT "_c"."cat" FROM (SELECT "breed_46" as "breed","cat_48" as "cat" FROM t11) as "_c")) UNION (SELECT "_d"."dog" FROM (SELECT "breed_56" as "breed","dog_58" as "dog" FROM t12) as "_d")"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }
@@ -233,7 +233,7 @@ class SqlizerJoinTest  extends SqlizerTest {
          SELECT name FROM @dog UNioN aLL
          SELECT name FROM @bird UnioN
          SELECT name FROM @fish"""
-    val expected = """SELECT "_t".primary_type FROM t1 as "_t" EXCEPT SELECT "name_45" FROM t11 INTERSECT SELECT "name_55" FROM t12 UNION ALL SELECT "name_65" FROM t13 UNION SELECT "name_65" FROM t14"""
+    val expected = """((((SELECT "_t".primary_type FROM t1 as "_t") EXCEPT (SELECT "name_45" FROM t11)) INTERSECT (SELECT "name_55" FROM t12)) UNION ALL (SELECT "name_65" FROM t13)) UNION (SELECT "name_65" FROM t14)"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
@@ -200,20 +200,20 @@ class SoQLUnionTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBa
   }
 
   test("Sqlize - union no table alias") {
-    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 WHERE (? != ?) UNION SELECT "t2".u_name_4 as "name" FROM t2 WHERE ("t2".u_year_6 = ?)) AS "x1" ORDER BY "name" nulls last""",
+    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM ((SELECT "t1".u_name_4 as "name" FROM t1 WHERE (? != ?)) UNION (SELECT "t2".u_name_4 as "name" FROM t2 WHERE ("t2".u_year_6 = ?))) AS "x1" ORDER BY "name" nulls last""",
       Seq(3, 2, 1))
   }
 
   test("Sqlize - union table alias") {
-    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 UNION SELECT "_d1".u_name_4 as "name" FROM t2 as "_d1" GROUP BY "_d1".u_name_4) AS "x1" ORDER BY "name" nulls last""")
+    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM ((SELECT "t1".u_name_4 as "name" FROM t1) UNION (SELECT "_d1".u_name_4 as "name" FROM t2 as "_d1" GROUP BY "_d1".u_name_4)) AS "x1" ORDER BY "name" nulls last""")
   }
 
   test("Sqlize - urls") {
-    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM (SELECT "t1".u_url_8_url as "url_url","t1".u_url_8_description as "url_description","t1".u_cat_7 as "cat" FROM t1 WHERE ("t1".u_url_8_url is not null or "t1".u_url_8_description is not null) UNION SELECT "t2".u_url_8_url as "url_url","t2".u_url_8_description as "url_description","t2".u_dog_7 as "dog" FROM t2 WHERE ("t2".u_url_8_url is not null or "t2".u_url_8_description is not null)) AS "x1" ORDER BY "cat" nulls last""")
+    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM ((SELECT "t1".u_url_8_url as "url_url","t1".u_url_8_description as "url_description","t1".u_cat_7 as "cat" FROM t1 WHERE ("t1".u_url_8_url is not null or "t1".u_url_8_description is not null)) UNION (SELECT "t2".u_url_8_url as "url_url","t2".u_url_8_description as "url_description","t2".u_dog_7 as "dog" FROM t2 WHERE ("t2".u_url_8_url is not null or "t2".u_url_8_description is not null))) AS "x1" ORDER BY "cat" nulls last""")
   }
 
   test("Sqlize - mixed and nested") {
-    sqlizeTest(soqls("mixed and nested"), """SELECT "name","breed","b3","bird" FROM (SELECT "t1".u_name_4 as "name","_jd1"."breed" as "breed","_jd1"."dog" as "dog","t2".u_breed_5 as "b2","_jb1"."breed" as "b3","_jb1"."bird" as "bird" FROM t1 JOIN (SELECT "t2".u_breed_5 as "breed","t2".u_dog_7 as "dog","t2".u_year_6 as "year" FROM t2) as "_jd1" ON ("_jd1"."year" = "t1".u_year_6)  JOIN t2 ON ("t2".u_year_6 = "t1".u_year_6)  JOIN (SELECT "t3".u_breed_5 as "breed","t3".u_bird_8 as "bird","t3".u_year_6 as "year" FROM t3 WHERE (("t3".u_year_6 = ?) and (("t3".u_year_6 + ?) = ?)) UNION (SELECT "t4".u_breed_5 as "breed","t4".u_fish_8 as "fish",? as "_1" FROM t4 WHERE ("t4".u_year_6 = ?) GROUP BY "t4".u_breed_5,"t4".u_fish_8 UNION SELECT "_jb1".u_breed_5 as "breed","t3".u_bird_8 as "bird",? as "_1" FROM t3 JOIN t3 as "_jb1" ON ("t3".u_year_6 = "_jb1".u_year_6) WHERE ("t3".u_year_6 = ?))) as "_jb1" ON ("_jb1"."year" = "t1".u_year_6) WHERE ("t1".u_year_6 = ?)) AS "x1" ORDER BY "b3" nulls last,"bird" nulls last LIMIT 5""",
+    sqlizeTest(soqls("mixed and nested"), """SELECT "name","breed","b3","bird" FROM (SELECT "t1".u_name_4 as "name","_jd1"."breed" as "breed","_jd1"."dog" as "dog","t2".u_breed_5 as "b2","_jb1"."breed" as "b3","_jb1"."bird" as "bird" FROM t1 JOIN (SELECT "t2".u_breed_5 as "breed","t2".u_dog_7 as "dog","t2".u_year_6 as "year" FROM t2) as "_jd1" ON ("_jd1"."year" = "t1".u_year_6)  JOIN t2 ON ("t2".u_year_6 = "t1".u_year_6)  JOIN ((SELECT "t3".u_breed_5 as "breed","t3".u_bird_8 as "bird","t3".u_year_6 as "year" FROM t3 WHERE (("t3".u_year_6 = ?) and (("t3".u_year_6 + ?) = ?))) UNION ((SELECT "t4".u_breed_5 as "breed","t4".u_fish_8 as "fish",? as "_1" FROM t4 WHERE ("t4".u_year_6 = ?) GROUP BY "t4".u_breed_5,"t4".u_fish_8) UNION (SELECT "_jb1".u_breed_5 as "breed","t3".u_bird_8 as "bird",? as "_1" FROM t3 JOIN t3 as "_jb1" ON ("t3".u_year_6 = "_jb1".u_year_6) WHERE ("t3".u_year_6 = ?)))) as "_jb1" ON ("_jb1"."year" = "t1".u_year_6) WHERE ("t1".u_year_6 = ?)) AS "x1" ORDER BY "b3" nulls last,"bird" nulls last LIMIT 5""",
       Seq(1, 1, 2, 1, 2, 1, 3, 1))
   }
 


### PR DESCRIPTION
Sometimes `select blah OP select bleh` is fine, but sometimes it
absolutely needs to be `(select blah) OP...` (e.g., if it has a LIMIT.
Since it's never _wrong_ to fully-parenthesize, just always do that.