### PR TITLE
EN-47916: Be able to preserve parentheses in compound queries

### DIFF
--- a/common-pg/src/main/scala/com/socrata/soql/analyzer/SoQLAnalyzerHelper.scala
+++ b/common-pg/src/main/scala/com/socrata/soql/analyzer/SoQLAnalyzerHelper.scala
@@ -54,7 +54,7 @@ object SoQLAnalyzerHelper {
     def toUserColumnId(columnName: ColumnName) = new UserColumnId(columnName.name)
 
     analyses match {
-      case PipeQuery(l, r) =>
+      case PipeQuery(l, r, _) =>
         val nl = remapAnalyses(columnIdMapping, l)
         val prev = nl.outputSchema.leaf
         val ra = r.asLeaf.get
@@ -70,11 +70,11 @@ object SoQLAnalyzerHelper {
         }
         val nr = r.asLeaf.get.mapColumnIds(prevQColumnIdToQColumnIdMap, toColumnNameJoinAlias, toUserColumnId, toUserColumnId)
         PipeQuery(nl, Leaf(nr))
-      case Compound(op, l, r) =>
+      case c@Compound(op, l, r) =>
         val la = remapAnalyses(columnIdMapping, l)
         val ra = remapAnalyses(columnIdMapping, r)
-        Compound(op, la, ra)
-      case Leaf(analysis) =>
+        Compound(op, la, ra, c.inParen)
+      case Leaf(analysis, inParen) =>
         val newMappingThisAlias = analysis.from match {
           case Some(tn@TableName(TableName.This, Some(_))) =>
             newMapping.foldLeft(newMapping) { (acc, mapEntry) =>
@@ -91,7 +91,7 @@ object SoQLAnalyzerHelper {
         }
 
         val remapped: SoQLAnalysis[UserColumnId, SoQLType] = analysis.mapColumnIds(newMappingThisAlias, toColumnNameJoinAlias, toUserColumnId, toUserColumnId)
-        Leaf(remapped)
+        Leaf(remapped, inParen)
     }
   }
 

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -242,7 +242,27 @@ class SqlizerJoinTest  extends SqlizerTest {
     val soql = "SELECT @t.:id FROM @this as t |> SELECT @t2.:id, @d.:id as id2 FROM @this as t2 JOIN @dog as d ON true"
     val expected = """SELECT "_t2".":id","_d".":id_51" FROM (SELECT "_t".":id_1" as ":id" FROM t1 as "_t") as "_t2" JOIN t12 as "_d" ON ?"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive, useRepsWithId = true)
-    println(sql)
+    sql should be (expected)
+  }
+
+  test("parentheses on the left are preserved") {
+    val soql = "(SELECT primary_type UNION SELECT name FROM @dog) INTERSECT SELECT name FROM @bird"
+    val expected = """(SELECT "t1".primary_type_7 FROM t1 UNION SELECT "name_55" FROM t12) INTERSECT SELECT "name_65" FROM t13"""
+    val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive, useRepsWithId = true)
+    sql should be (expected)
+  }
+
+  test("parentheses in leaves are preserved") {
+    val soql = "(SELECT primary_type ORDER BY case_number) UNION (SELECT name FROM @dog)"
+    val expected = """(SELECT "t1".primary_type_7 FROM t1 ORDER BY "t1".case_number_6 nulls last) UNION (SELECT "name_55" FROM t12)"""
+    val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive, useRepsWithId = true)
+    sql should be (expected)
+  }
+
+  test("standalone parentheses are preserved") {
+    val soql = "(SELECT primary_type ORDER BY case_number)"
+    val expected = """(SELECT "t1".primary_type_7 FROM t1 ORDER BY "t1".case_number_6 nulls last)"""
+    val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive, useRepsWithId = true)
     sql should be (expected)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "3.7.1"
+    val soqlStdlib = "3.8.0"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.10"
     val typesafeScalaLogging = "3.9.2"

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -195,7 +195,7 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
     val etag = analyses match {
       case Compound(op, l, r) =>
         createEtagFromAnalysis(l, fromTable, Map.empty) + op + createEtagFromAnalysis(r, fromTable, Map.empty)
-      case Leaf(analysis) =>
+      case Leaf(analysis, _) =>
         if (analysis.from.isDefined) analysis.toString()
         else analysis.toStringWithFrom(TableName(fromTable))
     }


### PR DESCRIPTION
Previously, parentheses can only influence the left, right structure of binary tree.  This doesn't work well with set operations that are different in precedence.