### PR TITLE
EN-47916: More aggressively generate parentheses in compound queries

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SoQLAnalysisSqlizer.scala
@@ -138,9 +138,8 @@ object BinarySoQLAnalysisSqlizer extends Sqlizer[(BinaryTree[SoQLAnalysis[UserCo
             case _ =>
               ls
           }
-          val sql = if (r.asLeaf.nonEmpty) s"${lsql} $sqlQueryOp ${rs}"
-                    else s"${lsql} $sqlQueryOp (${rs})"
-          s"$sql"
+          if (r.asLeaf.nonEmpty) s"${lsql} $sqlQueryOp ${rs}"
+          else s"${lsql} $sqlQueryOp (${rs})"
         }
         (ParametricSql(unionSql, setParamsAcc), lpcts + rpcts)
       case Leaf(analysis) =>

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerJoinTest.scala
@@ -233,7 +233,7 @@ class SqlizerJoinTest  extends SqlizerTest {
          SELECT name FROM @dog UNioN aLL
          SELECT name FROM @bird UnioN
          SELECT name FROM @fish"""
-    val expected = """SELECT "_t".primary_type FROM t1 as "_t" EXCEPT SELECT "name_45" FROM t11 INTERSECT SELECT "name_55" FROM t12 UNION ALL SELECT "name_65" FROM t13 UNION SELECT "name_65" FROM t14"""
+    val expected = """(((SELECT "_t".primary_type FROM t1 as "_t" EXCEPT SELECT "name_45" FROM t11) INTERSECT SELECT "name_55" FROM t12) UNION ALL SELECT "name_65" FROM t13) UNION SELECT "name_65" FROM t14"""
     val ParametricSql(Seq(sql), _) = sqlize(soql, CaseSensitive)
     sql should be (expected)
   }

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLUnionTest.scala
@@ -206,16 +206,16 @@ class SoQLUnionTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBa
   }
 
   test("Sqlize - union no table alias") {
-    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 WHERE (? != ?) UNION SELECT "t2".u_name_4 as "name" FROM t2 WHERE ("t2".u_year_6 = ?)) AS "x1" ORDER BY "name" nulls last""",
+    sqlizeTest(soqls("union no table alias"), """SELECT "name" FROM ((SELECT "t1".u_name_4 as "name" FROM t1 WHERE (? != ?) UNION SELECT "t2".u_name_4 as "name" FROM t2 WHERE ("t2".u_year_6 = ?))) AS "x1" ORDER BY "name" nulls last""",
       Seq(3, 2, 1))
   }
 
   test("Sqlize - union table alias") {
-    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM (SELECT "t1".u_name_4 as "name" FROM t1 UNION SELECT "_d1".u_name_4 as "name" FROM t2 as "_d1" GROUP BY "_d1".u_name_4) AS "x1" ORDER BY "name" nulls last""")
+    sqlizeTest(soqls("union table alias"), """SELECT "name" FROM ((SELECT "t1".u_name_4 as "name" FROM t1 UNION SELECT "_d1".u_name_4 as "name" FROM t2 as "_d1" GROUP BY "_d1".u_name_4)) AS "x1" ORDER BY "name" nulls last""")
   }
 
   test("Sqlize - urls") {
-    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM (SELECT "t1".u_url_8_url as "url_url","t1".u_url_8_description as "url_description","t1".u_cat_7 as "cat" FROM t1 WHERE ("t1".u_url_8_url is not null or "t1".u_url_8_description is not null) UNION SELECT "t2".u_url_8_url as "url_url","t2".u_url_8_description as "url_description","t2".u_dog_7 as "dog" FROM t2 WHERE ("t2".u_url_8_url is not null or "t2".u_url_8_description is not null)) AS "x1" ORDER BY "cat" nulls last""")
+    sqlizeTest(soqls("urls"), """SELECT "url_url","url_description" FROM ((SELECT "t1".u_url_8_url as "url_url","t1".u_url_8_description as "url_description","t1".u_cat_7 as "cat" FROM t1 WHERE ("t1".u_url_8_url is not null or "t1".u_url_8_description is not null) UNION SELECT "t2".u_url_8_url as "url_url","t2".u_url_8_description as "url_description","t2".u_dog_7 as "dog" FROM t2 WHERE ("t2".u_url_8_url is not null or "t2".u_url_8_description is not null))) AS "x1" ORDER BY "cat" nulls last""")
   }
 
   test("Sqlize - mixed and nested") {


### PR DESCRIPTION
(SELECT A UNION SELECT B) INTERSECT SELECT C
Should behave correctly