### PR TITLE
EN-49341: More improvement in error handling 400 (previously 500)

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlizeError.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlizeError.scala
@@ -1,0 +1,26 @@
+package com.socrata.pg.soql
+
+import com.socrata.soql.types.{SoQLFixedTimestamp, SoQLFloatingTimestamp, SoQLInterval, SoQLType}
+
+sealed trait SqlizeError extends Exception {
+  val value: String
+
+  override def getMessage(): String = {
+    s"${this.getClass.getSimpleName} $value"
+  }
+}
+
+case class InvalidInterval(value: String) extends SqlizeError
+case class InvalidTimestamp(value: String) extends SqlizeError
+case class InvalidTimezone(value: String) extends SqlizeError
+class InvalidConversion(val value: String) extends SqlizeError
+object InvalidConversion {
+  def apply(soqlType: SoQLType, value: String): SqlizeError = {
+    soqlType match {
+      case SoQLFloatingTimestamp => InvalidTimestamp(value)
+      case SoQLFixedTimestamp => InvalidTimestamp(value)
+      case SoQLInterval => InvalidInterval(value)
+      case _ => new InvalidConversion(value)
+    }
+  }
+}

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QCRequestError.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QCRequestError.scala
@@ -1,0 +1,16 @@
+package com.socrata.pg.server
+
+import com.rojoma.json.v3.ast.{JObject, JString}
+import com.rojoma.json.v3.util.AutomaticJsonCodecBuilder
+
+import javax.servlet.http.HttpServletResponse
+
+
+case class QCRequestError(description: String,
+                          errorCode: String = HttpServletResponse.SC_BAD_REQUEST.toString,
+                          data: JObject = JObject(Map("source" -> JString("soql-server"))))
+
+object QCRequestError {
+  implicit val qcRequestErrorCodec = AutomaticJsonCodecBuilder[QCRequestError]
+}
+


### PR DESCRIPTION
Select ‘invalid-period’::interval
Select ‘P1Y’::interval -- valid period but we do not support output
Select ‘t1rue’::boolean
Select ‘t1rue’:: number