### PR TITLE
Streamline datetime literal parameters

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
@@ -185,6 +185,8 @@ object SqlizerContext extends Enumeration {
   val IsSubQuery = Value("is-sub-query")
   val InsideWindowFn = Value("inside-window-fn")
   val LeadingSearch = Value("leading-search")
+
+  val TimestampLiteral = Value("timestamp-literal")
 }
 
 sealed trait CaseSensitivity


### PR DESCRIPTION
Previously going through cstring:
Filter: ((u_4n3z_8mii_6 >= ('2020-02-11T00:00:00.000'::cstring)::timestamp without time zone)

New:
Filter: (u_xh59_u4rh_18 = '2016-01-01 03:00:00'::timestamp without time zone)