### PR TITLE
reproject soql function

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctionsGeometry.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctionsGeometry.scala
@@ -68,6 +68,7 @@ trait SqlFunctionsGeometry {
     SimplifyPreserveTopology -> formatSimplify("ST_SimplifyPreserveTopology(%s, %s)") _,
     SnapToGrid -> formatSimplify("ST_SnapToGrid(%s, %s)") _,
     SnapForZoom -> snapForZoom _,
+    Reproject -> formatCall("ST_Transform(%s, %s, %s)") _,
     PointToLatitude -> formatCall("ST_Y(%s)::numeric") _,
     PointToLongitude -> formatCall("ST_X(%s)::numeric") _,
     VisibleAt -> visibleAt,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.0.1"
+    val soqlStdlib = "4.0.3"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.12"
     val typesafeScalaLogging = "3.9.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.0.3"
+    val soqlStdlib = "4.1.0"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.12"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
Adds:
A `reproject` SoQL function that loosely does what ST_Transform does in PostGIS, however it is setup to accept only the Proj4 projection text, rather than SRID integers, in order to allow for greater flexibility as well as match what DSMAPI does as a transform: https://dev.socrata.com/docs/transforms/reproject.html

Example: 
```
reproject('POINT (372728.3308536674 69825.24782297359)'::point, '+init=epsg:3627', '+init=epsg:4326')
```