### PR TITLE
Rollup improvements

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20220218-add-rollup-table-name.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20220218-add-rollup-table-name.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="robertm" id="20220218-add-rollup-table-name">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="rollup_map" columnName="table_name"/>
+            </not>
+        </preConditions>
+        <sql>
+          create extension if not exists pgcrypto; <!-- for "digest" -->
+          alter table rollup_map add column table_name text null;
+
+          update rollup_map
+          set
+            table_name = (
+              select
+               't' || cm.dataset_system_id || '_' || cm.copy_number || coalesce('_' || cmtm.table_modifier, '') || '_r_' || cm.data_version || '_' || substring(encode(digest(rollup_map.name, 'sha1'), 'hex'), 1, 16)
+              from
+                copy_map cm
+                left outer join copy_map_table_modifiers cmtm on cmtm.copy_system_id = cm.system_id
+              where cm.system_id = rollup_map.copy_system_id
+            );
+
+          alter table rollup_map alter column table_name set not null;
+        </sql>
+        <rollback>
+          <sql>
+            alter table rollup_map drop column table_name;
+          </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -27,4 +27,5 @@
     <include file="com/socrata/pg/store/schema/20200901-create-index-directive-map.xml"/>
     <include file="com/socrata/pg/store/schema/20210420-create-single_row.xml"/>
     <include file="com/socrata/pg/store/schema/20220208-add-data-shape-version.xml"/>
+    <include file="com/socrata/pg/store/schema/20220218-add-rollup-table-name.xml"/>
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/store/LocalRollupInfo.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/LocalRollupInfo.scala
@@ -1,0 +1,22 @@
+package com.socrata.pg.store
+
+import java.security.MessageDigest
+
+import com.socrata.datacoordinator.id.RollupName
+import com.socrata.datacoordinator.truth.metadata.{CopyInfo, RollupInfo}
+
+class LocalRollupInfo(copyInfo: CopyInfo, name: RollupName, soql: String, val tableName: String)(implicit tag: com.socrata.datacoordinator.truth.metadata.`-impl`.Tag) extends RollupInfo(copyInfo, name, soql) {
+  def updateName(newTableName: String) = new LocalRollupInfo(copyInfo, name, soql, newTableName)
+}
+
+object LocalRollupInfo {
+  def tableName(copyInfo: CopyInfo, name: RollupName): String = {
+    val sha1 = MessageDigest.getInstance("SHA-1")
+    // we have a 63 char limit on table names, so just taking a prefix.  It only has to be
+    // unique within a single dataset copy.
+    val bytes = 8
+    val nameHash = sha1.digest(name.underlying.getBytes("UTF-8")).take(bytes).map("%02x" format _).mkString
+
+    copyInfo.dataTableName + "_r_" + copyInfo.dataVersion + "_" + nameHash
+  }
+}

--- a/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryDatasetMapReader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryDatasetMapReader.scala
@@ -2,9 +2,47 @@ package com.socrata.pg.store
 
 import java.sql.Connection
 import com.rojoma.simplearm.v2._
-import com.socrata.datacoordinator.id.DatasetId
+import com.socrata.datacoordinator.id.{DatasetId, RollupName}
+import com.socrata.datacoordinator.util.TimingReport
+import com.socrata.datacoordinator.truth.metadata.sql.{PostgresDatasetMapReader, BasePostgresDatasetMapReader}
+import com.socrata.datacoordinator.truth.metadata.{TypeNamespace, CopyInfo}
+import com.socrata.soql.types.SoQLType
 
-class PGSecondaryDatasetMapReader(val conn: Connection) {
+trait LocalRollupReaderOverride[CT] { self: BasePostgresDatasetMapReader[CT] =>
+  def localRollupsQuery = "SELECT name, soql, table_name FROM rollup_map WHERE copy_system_id = ?"
+  override def rollups(copyInfo: CopyInfo): Seq[LocalRollupInfo] = {
+    using(conn.prepareStatement(localRollupsQuery)) { stmt =>
+      stmt.setLong(1, copyInfo.systemId.underlying)
+      using(t("rollups", "copy_id" -> copyInfo.systemId)(stmt.executeQuery())) { rs =>
+        val res = Vector.newBuilder[LocalRollupInfo]
+        while(rs.next()) {
+          res += new LocalRollupInfo(copyInfo, new RollupName(rs.getString("name")), rs.getString("soql"), rs.getString("table_name"))
+        }
+        res.result()
+      }
+    }
+  }
+
+  def localRollupQuery = "SELECT soql, table_name FROM rollup_map WHERE copy_system_id = ? AND name = ?"
+  override def rollup(copyInfo: CopyInfo, name: RollupName): Option[LocalRollupInfo] = {
+    using(conn.prepareStatement(localRollupQuery)) { stmt =>
+      stmt.setLong(1, copyInfo.systemId.underlying)
+      stmt.setString(2, name.underlying)
+      using(t("rollup", "copy_id" -> copyInfo.systemId,"name" -> name)(stmt.executeQuery())) { rs =>
+        if(rs.next()) {
+          Some(new LocalRollupInfo(copyInfo, name, rs.getString("soql"), rs.getString("table_name")))
+        } else {
+          None
+        }
+      }
+    }
+  }
+}
+
+class PGSecondaryDatasetMapReader[CT](conn: Connection, tns: TypeNamespace[CT], timingReport: TimingReport)
+    extends PostgresDatasetMapReader[CT](conn, tns, timingReport)
+    with LocalRollupReaderOverride[CT]
+{
   val idFromName =
     """SELECT dataset_system_id, disabled
       |  FROM dataset_internal_name_map

--- a/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryUniverse.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryUniverse.scala
@@ -93,12 +93,8 @@ class PGSecondaryUniverse[SoQLType, SoQLValue](
     new PGSecondaryDatasetMapWriter(conn, typeContext.typeNamespace,
       timingReport, obfuscationKeyGenerator, initialCounterValue, commonSupport.initialLatestDataVersion)
 
-  lazy val datasetMapReader: DatasetMapReader[SoQLType] =
-    new PostgresDatasetMapReader(conn, typeContext.typeNamespace, timingReport)
-
-  lazy val secondaryDatasetMapReader = new PGSecondaryDatasetMapReader(conn)
-
-  lazy val secondaryDatasetMapWriter = datasetMapWriter // TODO: remove this alias
+  lazy val datasetMapReader: PGSecondaryDatasetMapReader[SoQLType] =
+    new PGSecondaryDatasetMapReader(conn, typeContext.typeNamespace, timingReport)
 
   lazy val datasetReader = DatasetReader(lowLevelDatabaseReader)
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/DatabaseTestBase.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/DatabaseTestBase.scala
@@ -104,7 +104,7 @@ trait DatabaseTestBase {
       truthDatasetId = datasetId
       val pgu = new PGSecondaryUniverse[SoQLType, SoQLValue](conn,  PostgresUniverseCommon)
       val dsName = s"$dcInstance.${datasetId.underlying}"
-      secDatasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(s"$dsName").getOrElse(
+      secDatasetId = pgu.datasetMapReader.datasetIdForInternalName(s"$dsName").getOrElse(
         throw new Exception("Fail to get secondary database id"))
       pgu.datasetMapReader.datasetInfo(secDatasetId).getOrElse(throw new Exception("fail to get dataset from secondary"))
       (truthDatasetId, secDatasetId)
@@ -114,10 +114,9 @@ trait DatabaseTestBase {
   def createRollup(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: CopyInfo): String = {
     val rollupInfo = pgu.datasetMapWriter.createOrUpdateRollup(copyInfo, new RollupName("roll1"), "select 'x'")
     val rm = new RollupManager(pgu, copyInfo)
-    rm.updateRollup(rollupInfo, None, copyInfo.dataVersion)
-    val rollupTableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
+    rm.updateRollup(rollupInfo, None, false)
     pgu.commit()
-    rollupTableName
+    rollupInfo.tableName
   }
 
   def fixtureRows(name: String): Iterator[JValue] = {

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapReaderTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapReaderTest.scala
@@ -46,18 +46,18 @@ class PGSecondaryDatasetMapReaderTest extends FunSuite with Matchers with Before
   }
 
   test("Reader can determine the DatasetId from a given Dataset Internal Name") {
-    withDb() { conn => {
-      createSchema(conn)
-      val datasetId: DatasetId = new PGSecondaryDatasetMapReader(conn).datasetIdForInternalName("Dataset Name").get
+    withPgu() { pgu =>
+      createSchema(pgu.conn)
+      val datasetId: DatasetId = pgu.datasetMapReader.datasetIdForInternalName("Dataset Name").get
       datasetId shouldEqual new DatasetId(123)
-    }}
+    }
   }
 
   test("Reader does not raise when Dataset Internal Name cannot be found") {
-    withDb() { conn => {
-      createSchema(conn)
-      new PGSecondaryDatasetMapReader(conn).datasetIdForInternalName("I do not exist")
+    withPgu() { pgu =>
+      createSchema(pgu.conn)
+      pgu.datasetMapReader.datasetIdForInternalName("I do not exist")
       // TODO Show Randy how to deal with the "None" case return value from the above method
-    }}
+    }
   }
 }

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapWriterTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapWriterTest.scala
@@ -41,21 +41,18 @@ class PGSecondaryDatasetMapWriterTest extends PGSecondaryTestBase with PGSeconda
   }
 
   test("Can create internal name mapping") {
-    withDb() {
-      conn => {
-        createSchema(conn)
-        val datasetMapWriter = new PGSecondaryDatasetMapWriter(conn, PostgresUniverseCommon.typeContext.typeNamespace, PostgresUniverseCommon.timingReport, noopKeyGen, ZeroID, ZeroVersion)
-        datasetMapWriter.createInternalNameMapping("Dataset Name", new DatasetId(123))
-        val datasetId: DatasetId = new PGSecondaryDatasetMapReader(conn).datasetIdForInternalName("Dataset Name").get
-        datasetId shouldEqual new DatasetId(123)
-      }
+    withPgu() { pgu =>
+      createSchema(pgu.conn)
+      pgu.datasetMapWriter.createInternalNameMapping("Dataset Name", new DatasetId(123))
+      val datasetId: DatasetId = pgu.datasetMapReader.datasetIdForInternalName("Dataset Name").get
+      datasetId shouldEqual new DatasetId(123)
     }
   }
 
   test("Can create dataset only") {
     withPgu() { pgu =>
       createSchema(pgu.conn)
-      val datasetId = pgu.secondaryDatasetMapWriter.createDatasetOnly("locale")
+      val datasetId = pgu.datasetMapWriter.createDatasetOnly("locale")
 
       val dataSetInfo = pgu.datasetMapReader.datasetInfo(datasetId).get
       pgu.datasetMapReader.allCopies(dataSetInfo) shouldBe empty
@@ -74,7 +71,7 @@ class PGSecondaryDatasetMapWriterTest extends PGSecondaryTestBase with PGSeconda
 
       pgu.conn.getMetaData().getTables(null, null, tableName, null).next() should be (true)
 
-      pgu.secondaryDatasetMapWriter.deleteCopy(truthCopyInfo)
+      pgu.datasetMapWriter.deleteCopy(truthCopyInfo)
 
       an [Exception] should be thrownBy getTruthCopyInfo(pgu, f.datasetInfo) // scalastyle:ignore
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryTestBase.scala
@@ -101,7 +101,7 @@ abstract class PGSecondaryTestBase extends FunSuite with Matchers with BeforeAnd
 
   def getTruthDatasetInfo(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
                           secondaryDatasetInfo: SecondaryDatasetInfo): TruthDatasetInfo = {
-    val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(secondaryDatasetInfo.internalName).getOrElse(
+    val datasetId = pgu.datasetMapReader.datasetIdForInternalName(secondaryDatasetInfo.internalName).getOrElse(
       throw new ResyncSecondaryException(s"Couldn't find mapping for datasetInternalName ${secondaryDatasetInfo.internalName}")
     )
     pgu.datasetMapReader.datasetInfo(datasetId).get

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupDropTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupDropTest.scala
@@ -77,7 +77,7 @@ class RollupDropTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBas
 
   private def rollupTableExists(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: CopyInfo): Unit = {
     val rollupTableName = pgu.datasetMapReader.rollups(copyInfo).map { rollupInfo =>
-      val rollupTableName = RollupManager.rollupTableName(rollupInfo, copyInfo.dataVersion)
+      val rollupTableName = rollupInfo.tableName
       val materialized = RollupManager.shouldMaterializeRollups(copyInfo.lifecycleStage)
       val expectedTable = if (materialized) 1 else 0
       jdbcColumnCount(pgu.conn, rollupTableName) should be (expectedTable)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyCreatedHandlerTest.scala
@@ -18,7 +18,7 @@ class WorkingCopyCreatedHandlerTest extends PGSecondaryTestBase with PGSecondary
   test("can handle working copy event") {
     withPgu() { pgu =>
       val datasetInfo = SecondaryDatasetInfo(testInternalName, localeName, obfuscationKey, None)
-      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(testInternalName)
+      val datasetId = pgu.datasetMapReader.datasetIdForInternalName(testInternalName)
       val dataVersion = 0L
       val copyInfo = CopyInfo(new CopyId(-1), 1, LifecycleStage.Published, dataVersion, dataVersion, new DateTime())
       WorkingCopyCreatedHandler(pgu, datasetId, datasetInfo, copyInfo)
@@ -42,7 +42,7 @@ class WorkingCopyCreatedHandlerTest extends PGSecondaryTestBase with PGSecondary
       firstCopy.lifecycleStage should be (metadata.LifecycleStage.Unpublished)
       firstCopy.copyNumber should be (1L)
 
-      val datasetId = pgu.secondaryDatasetMapReader.datasetIdForInternalName(datasetInfo.internalName)
+      val datasetId = pgu.datasetMapReader.datasetIdForInternalName(datasetInfo.internalName)
       datasetId.isDefined should be (true)
       WorkingCopyPublishedHandler(pgu, firstCopy)
       val firstCopyPublished = getTruthCopyInfo(pgu, datasetInfo)


### PR DESCRIPTION
* Allow moving rollups between data versions
* Allow populating rollups on `optimize`