### PR TITLE
EN-51220: Indirect literals should not generate timestamp parameters

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
@@ -625,7 +625,7 @@ object SqlFunctions extends SqlFunctionsLocation with SqlFunctionsGeometry with 
     }
 
     val litCtx = soqlType match {
-      case SoQLFloatingTimestamp | SoQLFixedTimestamp =>
+      case SoQLFloatingTimestamp | SoQLFixedTimestamp if isImmediateLiteral(fn.parameters.head) =>
         ctx + (SqlizerContext.TimestampLiteral -> true)
       case _ =>
         ctx

--- a/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
@@ -151,6 +151,13 @@ object Sqlizer {
           fc.parameters.forall(x => isLiteral(x))
     }
   }
+
+  def isImmediateLiteral(expr: CoreExpr[UserColumnId, SoQLType]): Boolean = {
+    expr match {
+      case lit: TypedLiteral[SoQLType] => true
+      case _ => false
+    }
+  }
 }
 
 object SqlizerContext extends Enumeration {

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -544,4 +544,12 @@ class SqlizerBasicTest extends SqlizerTest {
     params should be (Seq(ts1, ts2, ts3, ts4))
     sql should be ("SELECT (trunc((extract(epoch from (?::timestamp)) - extract(epoch from (?::timestamp)))::numeric / 86400)),(trunc((extract(epoch from (?::timestamp with time zone)) - extract(epoch from (?::timestamp with time zone)))::numeric / 86400))")
   }
+
+  test("indirect literals should not generate timestamp parameters") {
+    val soql = "select ('2021-12-' || '25')::floating_timestamp from @single_row"
+    val ParametricSql(Seq(sql), setParams) = sqlize(soql, CaseSensitive)
+    val params = setParams.map { (setParam) => setParam(None, 0).get }
+    params should be (Seq("2021-12-", "25")) // all parameters are text, no Timestamps
+    sql should be ("SELECT ((? || ?)::timestamp)")
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.2.0"
+    val soqlStdlib = "4.3.0"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "3.8.19"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
Previously, these are failing:

SELECT
(
date_extract_y(floating_timestamp) || '-' || left_pad(date_extract_m(floating_timestamp) :: text, 2, '0') || '-' || left_pad(date_extract_d(floating_timestamp) :: text, 2, '0') 
)::floating_timestamp

SELECT (‘2020-‘ || ’02-02’)::floating_teimstamp