### PR TITLE
EN-49039: Limit $$query_timeout_seconds to 10 minutes unless it is debug

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
@@ -18,7 +18,6 @@ import com.socrata.soql.types.obfuscation.CryptProvider
 import com.socrata.soql.types.{SoQLID, SoQLType, SoQLValue, SoQLVersion}
 
 import java.sql.Connection
-import scala.concurrent.duration.FiniteDuration
 
 object QueryServerHelper {
 

--- a/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
@@ -18,6 +18,7 @@ import com.socrata.soql.types.obfuscation.CryptProvider
 import com.socrata.soql.types.{SoQLID, SoQLType, SoQLValue, SoQLVersion}
 
 import java.sql.Connection
+import scala.concurrent.duration.FiniteDuration
 
 object QueryServerHelper {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.3.2"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "3.8.19"
+    val dataCoordinator = "3.8.21"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"

--- a/soql-server-pg/src/main/resources/reference.conf
+++ b/soql-server-pg/src/main/resources/reference.conf
@@ -43,6 +43,9 @@ com.socrata.soql-server-pg {
   # the impact one dataset can have on the service.
   max-concurrent-requests-per-dataset = 15
 
+  max-query-timeout = "10m"
+  http-query-timeout-delta = "2s"
+
   threadpool {
     min-threads = 10
     max-threads = 100

--- a/soql-server-pg/src/main/resources/reference.conf
+++ b/soql-server-pg/src/main/resources/reference.conf
@@ -44,6 +44,7 @@ com.socrata.soql-server-pg {
   max-concurrent-requests-per-dataset = 15
 
   max-query-timeout = "10m"
+
   http-query-timeout-delta = "2s"
 
   threadpool {

--- a/soql-server-pg/src/main/resources/reference.conf
+++ b/soql-server-pg/src/main/resources/reference.conf
@@ -43,8 +43,6 @@ com.socrata.soql-server-pg {
   # the impact one dataset can have on the service.
   max-concurrent-requests-per-dataset = 15
 
-  max-query-timeout = "10m"
-
   http-query-timeout-delta = "2s"
 
   threadpool {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -67,7 +67,8 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.collection.immutable.SortedMap
 import scala.language.existentials
 
-class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val leadingSearch: Boolean = true) extends SecondaryBase {
+class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val leadingSearch: Boolean = true,
+                  val maxQueryTimeoutSeconds: Int = 60000, val httpQueryTimeoutDelta: FiniteDuration = Duration.Zero) extends SecondaryBase {
   import QueryServer._ // scalastyle:ignore import.grouping
   import QueryServerHelper._
   import com.socrata.pg.query.QueryResult._
@@ -526,10 +527,14 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
                             && precondition == NoPrecondition =>
             NotModified(Seq(etag))
           case Some(_) | None =>
+            if (queryTimeout.exists(timeout => timeout.toSeconds > maxQueryTimeoutSeconds && !debug)) {
+              return QueryError(s"query timeout exceeds maximum of ${maxQueryTimeoutSeconds}s")
+            }
+            val qto = queryTimeout.map(_.minus(httpQueryTimeoutDelta)) // can go negative which is handled by downstream function
             try {
-              runQuery(pgu, context, copy, analysis, rowCount, queryTimeout, explain, analyze) match {
+              runQuery(pgu, context, copy, analysis, rowCount, qto, explain, analyze) match {
                 case RowsQueryResult(qrySchema, version, results) =>
-                  Success (qrySchema, copy.copyNumber, version, results, etag, lastModified)
+                  Success(qrySchema, copy.copyNumber, version, results, etag, lastModified)
                 case InfoQueryResult(dataVersion, explainInfo) =>
                   InfoSuccess(copy.copyNumber, dataVersion, explainInfo)
               }
@@ -684,7 +689,7 @@ object QueryServer extends DynamicPortMap {
       reporter <- MetricsReporter.managed(config.metrics)
     } {
       pong.start()
-      val queryServer = new QueryServer(dsInfo, CaseSensitive, config.leadingSearch)
+      val queryServer = new QueryServer(dsInfo, CaseSensitive, config.leadingSearch, config.maxQueryTimeout.toSeconds.toInt, config.httpQueryTimeoutDelta)
       val advertisedLivenessCheckInfo = new LivenessCheckInfo(hostPort(pong.livenessCheckInfo.getPort),
                                                               pong.livenessCheckInfo.getResponse)
       val auxData = new AuxiliaryData(livenessCheckInfo = Some(advertisedLivenessCheckInfo))

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/config/QueryServerConfig.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/config/QueryServerConfig.scala
@@ -19,4 +19,6 @@ class QueryServerConfig(val config: Config, val root: String) extends ConfigClas
   val threadpool = getRawConfig("threadpool")
   val maxConcurrentRequestsPerDataset = getInt("max-concurrent-requests-per-dataset")
   val leadingSearch = getBoolean("leading-search")
+  val maxQueryTimeout = getDuration("max-query-timeout")
+  val httpQueryTimeoutDelta = getDuration("http-query-timeout-delta")
 }

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/config/QueryServerConfig.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/config/QueryServerConfig.scala
@@ -19,6 +19,5 @@ class QueryServerConfig(val config: Config, val root: String) extends ConfigClas
   val threadpool = getRawConfig("threadpool")
   val maxConcurrentRequestsPerDataset = getInt("max-concurrent-requests-per-dataset")
   val leadingSearch = getBoolean("leading-search")
-  val maxQueryTimeout = getDuration("max-query-timeout")
   val httpQueryTimeoutDelta = getDuration("http-query-timeout-delta")
 }

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
@@ -76,7 +76,7 @@ trait PGQueryServerDatabaseTestBase extends DatabaseTestBase with PGSecondaryUni
 
         val (qrySchema, dataVersion, mresult) =
           ds.run { dsInfo =>
-            val qs = new QueryServer(dsInfo, caseSensitivity, leadingSearch, 60000, Duration.Zero)
+            val qs = new QueryServer(dsInfo, caseSensitivity, leadingSearch, Duration.Zero)
             qs.execQuery(pgu, context, "someDatasetInternalName", copyInfo.datasetInfo, analyses, expectedRowCount.isDefined, None, None, true,
               NoPrecondition, None, None, None, None, false, false, false) match {
               case QueryResult.Success(schema, _, version, results, etag, lastModified) =>

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/PGQueryServerDatabaseTestBase.scala
@@ -19,6 +19,7 @@ import com.socrata.soql.stdlib.{Context => SoQLContext}
 import com.socrata.soql.types.{SoQLType, SoQLValue}
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 
+import scala.concurrent.duration.Duration
 import scala.language.existentials
 
 // scalastyle:off method.length
@@ -75,7 +76,7 @@ trait PGQueryServerDatabaseTestBase extends DatabaseTestBase with PGSecondaryUni
 
         val (qrySchema, dataVersion, mresult) =
           ds.run { dsInfo =>
-            val qs = new QueryServer(dsInfo, caseSensitivity, leadingSearch)
+            val qs = new QueryServer(dsInfo, caseSensitivity, leadingSearch, 60000, Duration.Zero)
             qs.execQuery(pgu, context, "someDatasetInternalName", copyInfo.datasetInfo, analyses, expectedRowCount.isDefined, None, None, true,
               NoPrecondition, None, None, None, None, false, false, false) match {
               case QueryResult.Success(schema, _, version, results, etag, lastModified) =>

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryServerTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryServerTest.scala
@@ -1,18 +1,20 @@
 package com.socrata.pg.server
 
-import com.socrata.datacoordinator.common.DataSourceConfig
 import com.socrata.pg.store.PGSecondaryUniverse
-import com.socrata.soql.types.{SoQLValue, SoQLType}
+import com.socrata.soql.types.{SoQLType, SoQLValue}
 import com.socrata.datacoordinator.secondary.DatasetInfo
 import com.socrata.datacoordinator.common.DataSourceFromConfig.DSInfo
 import com.socrata.pg.soql.CaseSensitive
+
+import scala.concurrent.duration.Duration
 
 /**
  * Allow a pg secondary universe passed in so that tests can read what have just been written.
  * @param dsInfo
  * @param pgu
  */
-class QueryServerTest(dsInfo:DSInfo, pgu: PGSecondaryUniverse[SoQLType, SoQLValue]) extends QueryServer(dsInfo, CaseSensitive, leadingSearch = true) {
+class QueryServerTest(dsInfo:DSInfo, pgu: PGSecondaryUniverse[SoQLType, SoQLValue]) extends
+  QueryServer(dsInfo, CaseSensitive, leadingSearch = true, 60000, Duration.Zero) {
 
   override protected def withPgu[T](dsInfo:DSInfo, truthStoreDatasetInfo:Option[DatasetInfo])(f: (PGSecondaryUniverse[SoQLType, SoQLValue]) => T): T = {
     f(pgu)

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryServerTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryServerTest.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.Duration
  * @param pgu
  */
 class QueryServerTest(dsInfo:DSInfo, pgu: PGSecondaryUniverse[SoQLType, SoQLValue]) extends
-  QueryServer(dsInfo, CaseSensitive, leadingSearch = true, 60000, Duration.Zero) {
+  QueryServer(dsInfo, CaseSensitive, leadingSearch = true, Duration.Zero) {
 
   override protected def withPgu[T](dsInfo:DSInfo, truthStoreDatasetInfo:Option[DatasetInfo])(f: (PGSecondaryUniverse[SoQLType, SoQLValue]) => T): T = {
     f(pgu)

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryTest.scala
@@ -67,7 +67,7 @@ class QueryTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBase w
           SoQLAnalyzerHelper.analyzeSoQL(soql, Map(TableName.PrimaryTable.qualifier -> datasetCtx), primaryTableColumnNameIdMap)
         val (requestColumns, version, mresult) =
           ds.run { dsInfo =>
-            val qs = new QueryServer(dsInfo, CaseSensitive, leadingSearch = true, 60000, Duration.Zero)
+            val qs = new QueryServer(dsInfo, CaseSensitive, leadingSearch = true, Duration.Zero)
             qs.execQuery(pgu, SoQLContext.empty, "someDatasetInternalName", copyInfo.datasetInfo, analyses, false, None, None, true,
               NoPrecondition, None, None, None, None, false, false, false) match {
               case QueryResult.Success(schema, _, version, results, etag, lastModified) =>

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/QueryTest.scala
@@ -19,6 +19,8 @@ import com.socrata.pg.soql.CaseSensitive
 import com.socrata.http.server.util.NoPrecondition
 import com.socrata.pg.query.{PGQueryTestBase, QueryResult}
 
+import scala.concurrent.duration.Duration
+
 class QueryTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBase with PGQueryTestBase {
 
   override def beforeAll: Unit = {
@@ -65,7 +67,7 @@ class QueryTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBase w
           SoQLAnalyzerHelper.analyzeSoQL(soql, Map(TableName.PrimaryTable.qualifier -> datasetCtx), primaryTableColumnNameIdMap)
         val (requestColumns, version, mresult) =
           ds.run { dsInfo =>
-            val qs = new QueryServer(dsInfo, CaseSensitive, leadingSearch = true)
+            val qs = new QueryServer(dsInfo, CaseSensitive, leadingSearch = true, 60000, Duration.Zero)
             qs.execQuery(pgu, SoQLContext.empty, "someDatasetInternalName", copyInfo.datasetInfo, analyses, false, None, None, true,
               NoPrecondition, None, None, None, None, false, false, false) match {
               case QueryResult.Success(schema, _, version, results, etag, lastModified) =>


### PR DESCRIPTION
so that we get a consistent sql timeout error

http-query-timeout-delta = "2s"