### PR TITLE
Limit precision on row-update progress logs

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/events/RowDataUpdatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/RowDataUpdatedHandler.scala
@@ -40,7 +40,7 @@ object RowDataUpdatedHandler {
         performedOps += 1
         val now = System.nanoTime()
         if(now - lastTickedAt > IntervalBetweenTicksNS) {
-          logger.info("Upsert progress: {}/{} ({}%) operations performed", performedOps, progress.expectedOps, 100.0 * performedOps.toDouble / progress.expectedOps)
+          logger.info("Upsert progress: {}/{} ({}%) operations performed", performedOps, progress.expectedOps, "%.2f".format(100.0 * performedOps.toDouble / progress.expectedOps))
           lastTickedAt = now
         }
       }


### PR DESCRIPTION
"81.97182190984103%" => "81.97%"