### PR TITLE
EN-52985: Delete did not drop the index

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/events/IndexDroppedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/IndexDroppedHandler.scala
@@ -11,7 +11,7 @@ import com.socrata.soql.types.{SoQLType, SoQLValue}
 case class IndexDroppedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
                                copyInfo: CopyInfo,
                                indexName: IndexName) {
-    pgu.datasetMapWriter.dropIndex(copyInfo, Some(indexName))
-    val im = new IndexManager(pgu, copyInfo)
-    im.dropIndex(indexName)
+  val im = new IndexManager(pgu, copyInfo)
+  im.dropIndex(indexName)
+  pgu.datasetMapWriter.dropIndex(copyInfo, Some(indexName))
 }


### PR DESCRIPTION
Because metadata was removed before actual drop which depends on the metadata.