### PR TITLE
Don't compile `get_context(stringlit)` to a current_setting call

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/Sqlizer.scala
@@ -194,6 +194,7 @@ object SqlizerContext extends Enumeration {
   val LeadingSearch = Value("leading-search")
 
   val TimestampLiteral = Value("timestamp-literal")
+  val SoQLContext = Value("soql-context")
 }
 
 sealed trait CaseSensitivity

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -430,7 +430,8 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
                                  else { new ClearNumberRep(cryptProvider) }),
         SqlizerContext.VerRep -> new SoQLVersion.StringRep(cryptProvider),
         SqlizerContext.CaseSensitivity -> caseSensitivity,
-        SqlizerContext.LeadingSearch -> leadingSearch
+        SqlizerContext.LeadingSearch -> leadingSearch,
+        SqlizerContext.SoQLContext -> context,
       )
       val escape = (stringLit: String) => SqlUtils.escapeString(pgu.conn, stringLit)
 

--- a/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLContextTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/server/SoQLContextTest.scala
@@ -28,7 +28,7 @@ class SoQLContextTest extends SoQLTest {
   }
 
   test("bunch of context") {
-    compareSoqlResult("select get_context('a') as a, get_context('b') as b, get_context('c') as c, get_context('d') as d, get_context('e') as e, get_context('f') as f, get_context('g') as g limit 1", "context-many.json",
+    compareSoqlResult("select get_context('a') as a, get_context('b') as b, get_context('c'||'') as c, get_context('d') as d, get_context('e') as e, get_context('f') as f, get_context('g') as g limit 1", "context-many.json",
                       context = Context(
                         system = Map("a" -> "1",
                                      "b" -> "2",


### PR DESCRIPTION
No need for it in that case, we can just look the value up in the map
ourselves and put it in the SQL as if it had been a string literal
itself.

If a non-string-literal is passed in, we'll still do the runtime lookup
but this should basically never happen.