### PR TITLE
Bump DC lib for

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20191224-add-some-dc-tables.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20191224-add-some-dc-tables.xml
@@ -26,4 +26,13 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="chi" id="20220721-add-secondary-manifest-cookie-column">
+        <!-- fake cookie column to keep SqlTableCleanup.cleanupDeleteds happy -->
+        <preConditions onFail="MARK_RAN">
+            <not><columnExists tableName="secondary_manifest" columnName="cookie"/></not>
+        </preConditions>
+        <addColumn tableName="secondary_manifest">
+            <column name="cookie" type="text"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.8.0"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "4.1.1"
+    val dataCoordinator = "4.1.2"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"


### PR DESCRIPTION
Occasionally we need to clean up orphans in secondaries.  We do not want this to race with SqlTableCleanup. (#369)

Put the special value '{}' in the cookie so that it will not be touched by SqlTableCleanup
Modified file