### PR TITLE
EN-55757 rollup usage metrics

### DIFF
--- a/common-pg/build.sbt
+++ b/common-pg/build.sbt
@@ -26,7 +26,8 @@ libraryDependencies ++= Seq(
   metricsJetty,
   metricsGraphite,
   metricsJmx,
-  scalatest % "test"
+  scalatest % "test",
+  rollupMetrics
 )
 
 enablePlugins(BuildInfoPlugin)

--- a/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryDatasetMapReader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/PGSecondaryDatasetMapReader.scala
@@ -185,4 +185,15 @@ class PGSecondaryDatasetMapReader[CT](conn: Connection, tns: TypeNamespace[CT], 
       }
     }
   }
+
+  def pgTotalRelationSizeQuery = "select pg_total_relation_size(?)"
+
+  def getTotalRelationSize(tableName: String): Option[Long] = {
+    using(conn.prepareStatement(pgTotalRelationSizeQuery)) { stmt =>
+      stmt.setString(1, tableName)
+      using(t("get-total-relation-size", "tableName" -> tableName)(stmt.executeQuery())) { rs =>
+        if (rs.next()) Some(rs.getLong(1)) else None
+      }
+    }
+  }
 }

--- a/common-pg/src/main/scala/com/socrata/util/Timing.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Timing.scala
@@ -1,0 +1,14 @@
+package com.socrata.util
+
+import scala.concurrent.duration.{Duration, MILLISECONDS}
+
+object Timing {
+
+  def wrap[T](block: =>T)(fun:(T,Duration)=>Unit): T ={
+    val start = System.currentTimeMillis()
+    val result = block
+    val end = System.currentTimeMillis()
+    fun(result,Duration(end-start,MILLISECONDS))
+    result
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val liquibasePlugin = "1.9.5.0"
     val postgresql = "9.4.1212"
     val simpleArm = "1.1.10"
-    val slf4j = "2.0.5"
+    val slf4j = "1.7.5"
     val scalatest = "3.0.8"
     val socrataUtils = "0.11.0"
     val socrataCuratorUtils = "1.2.0"
@@ -27,7 +27,7 @@ object Dependencies {
     val metrics = "4.1.2"
     val metricsScala = "4.1.1"
     val clojure = "1.5.1"
-    val rollupMetrics = "2.0"
+    val rollupMetrics = "2.2"
   }
 
   val c3p0 = "com.mchange" % "c3p0" % versions.c3p0
@@ -82,5 +82,5 @@ object Dependencies {
 
   val clojure = "org.clojure" % "clojure" % versions.clojure
 
-  val rollupMetrics = "rollup-metrics" %% "rollup-metrics" % versions.rollupMetrics
+  val rollupMetrics = "com.socrata" %% "rollup-metrics" % versions.rollupMetrics
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     val liquibasePlugin = "1.9.5.0"
     val postgresql = "9.4.1212"
     val simpleArm = "1.1.10"
-    val slf4j = "1.7.5"
+    val slf4j = "2.0.5"
     val scalatest = "3.0.8"
     val socrataUtils = "0.11.0"
     val socrataCuratorUtils = "1.2.0"
@@ -27,6 +27,7 @@ object Dependencies {
     val metrics = "4.1.2"
     val metricsScala = "4.1.1"
     val clojure = "1.5.1"
+    val rollupMetrics = "2.0"
   }
 
   val c3p0 = "com.mchange" % "c3p0" % versions.c3p0
@@ -80,4 +81,6 @@ object Dependencies {
   val metricsScala = "nl.grons" %% "metrics4-scala" % versions.metricsScala
 
   val clojure = "org.clojure" % "clojure" % versions.clojure
+
+  val rollupMetrics = "rollup-metrics" %% "rollup-metrics" % versions.rollupMetrics
 }


### PR DESCRIPTION
This change brings in a new library(rollup-metrics) and 
* logs the creation time and size of a rollup table that was built.
* logs when a rollup is hit

