### PR TITLE
Fix (I hope!) a really subtle bug involving joined rollups and replic…

### DIFF
--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -470,7 +470,7 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
         // 1. regular tablename contains dataset_map.resource_name
         // 2. rollup tablename contains dataset_map.resource_name + "." + rollup_map.name
         val relatedTableNames = removeTableAlias(collectRelatedTableNames(analysis))
-        val (relatedCopyMap, relatedRollupMap) = getCopyAndRollupMaps(pgu, relatedTableNames, reqCopy)
+        val (relatedCopyMap, relatedRollupMap) = getCopyAndRollupMaps(pgu, relatedTableNames, datasetInfo.resourceName.map(ResourceName(_)), reqCopy)
         val joinCopiesMap = relatedCopyMap ++ copyInfo.datasetInfo.resourceName.map(rn => Map(TableName(rn) -> copyInfo)).getOrElse(Map.empty)
 
         val sqlRepsWithJoin = relatedCopyMap.foldLeft(sqlReps) { (acc, joinCopy) =>

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -10,7 +10,7 @@ import com.socrata.pg.query.QueryServerHelper
 import com.socrata.pg.store.PGSecondaryUtil._
 import com.socrata.pg.store.events.{ColumnCreatedHandler, RollupCreatedOrUpdatedHandler, WorkingCopyCreatedHandler, WorkingCopyPublishedHandler}
 import com.socrata.soql.environment.TableName.PrimaryTable
-import com.socrata.soql.environment.{ColumnName, TableName}
+import com.socrata.soql.environment.{ColumnName, TableName, ResourceName}
 import com.socrata.soql.types._
 import org.joda.time.DateTime
 import org.scalatest.Matchers.fail
@@ -319,7 +319,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       // test getCopyAndRollupMaps
       val regularTableName = TableName(datasetInfo.resourceName.get)
       val rollupTableName = TableName(s"${datasetInfo.resourceName.get}.${rollupInfo.name.underlying}")
-      val (copyMap, rollupMap) = QueryServerHelper.getCopyAndRollupMaps(pgu,Seq(regularTableName, rollupTableName, PrimaryTable), None)
+      val (copyMap, rollupMap) = QueryServerHelper.getCopyAndRollupMaps(pgu,Seq(regularTableName, rollupTableName, PrimaryTable), datasetInfo.resourceName.map(ResourceName(_)), None)
       copyMap(regularTableName) should be (copyInfo)
       rollupMap(rollupTableName) should be (rollupInfo)
       copyMap.size should be (1)


### PR DESCRIPTION
…ations

Ok, so what's happening here was this:
 * We observed rollup replication for a particular dataset+rollup failing with a "no such table" postgresql error.
 * Upon investigating, we found that a joined-to (well, unioned-to) dataset was using copy 3 (a discarded copy!) rather than copy 4 (a published copy) of one of the other tables involved in the query.
 * Following the logic through, the query sqlizer uses the requested copy number of the current primary dataset.
 * For queries, this will effectively always be "published" and so it will always look up published copies of joined-to things, which is correct.
 * For replication it will be the current _copy number_ rather than one of the symbolic names.
 * So, since this was replicating, it was looking up copy 3 of this other dataset because we were replicating copy 3 of the base dataset!! (n.b., if it can't find the requested copy it silently switches to the "latest" copy, which is _also_ surprising and probably wrong but this commit doesn't change that; however, it is probable that this further masked the issue)

So what this does is:

 * Keep passing around the requested copy value down to the relevant finder
 * Because we want to use the same copy _if we're doing a self-join of some kind_
 * But only actually _use_ that requested copy if we are in fact doing a self-join, otherwise ask for the published copy of whatever we're joining to.