### PR TITLE
Use the new debug info

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SqlizeAnnotation.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SqlizeAnnotation.scala
@@ -6,4 +6,5 @@ sealed abstract class SqlizeAnnotation[MT <: MetaTypes] extends SqlizerUniverse[
 
 object SqlizeAnnotation {
   case class Expression[MT <: MetaTypes](expr: Expr[MT]) extends SqlizeAnnotation[MT]
+  case class Table[MT <: MetaTypes](table: AutoTableLabel) extends SqlizeAnnotation[MT]
 }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/Sqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/Sqlizer.scala
@@ -531,7 +531,7 @@ abstract class Sqlizer[MT <: MetaTypes] extends SqlizerUniverse[MT] {
       from match {
         case FromTable(name, _cn, _rn, _alias, label, columns, _pks) =>
           (
-            namespace.databaseTableName(name).annotate[SqlizeAnnotation](SqlizeAnnotation.Table(label)),
+            namespace.databaseTableName(name),
             OrderedMap() ++ columns.iterator.map { case (dcn, nameEntry) =>
               (dcn -> AugmentedType[MT](nameEntry.typ, isExpanded = true))
             }
@@ -545,7 +545,7 @@ abstract class Sqlizer[MT <: MetaTypes] extends SqlizerUniverse[MT] {
           (d"(SELECT)", OrderedMap.empty)
       }
 
-    (sql +#+ d"AS" +#+ namespace.tableLabel(from.label), availableSchemas + (from.label -> schema))
+    (sql.annotate[SqlizeAnnotation](SqlizeAnnotation.Table(from.label)) +#+ d"AS" +#+ namespace.tableLabel(from.label), availableSchemas + (from.label -> schema))
   }
 
   private def deSelectListReferenceWrappedToplevelExprs(selectList: Vector[Expr], distinct: Distinctiveness): Distinctiveness =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,6 +60,7 @@ object Dependencies {
   val socrataHttpCuratorBroker = "com.socrata" %% "socrata-http-curator-broker" % versions.socrataHttpCuratorBroker
 
   val soqlStdlib = "com.socrata" %% "soql-stdlib" % versions.soqlStdlib
+  val soqlUtils = "com.socrata" %% "soql-utils" % versions.soqlStdlib
 
   val typesafeConfig = "com.typesafe" % "config" % versions.typesafeConfig
 

--- a/soql-server-pg/build.sbt
+++ b/soql-server-pg/build.sbt
@@ -4,7 +4,8 @@ name := "soql-server-pg"
 
 libraryDependencies ++= Seq(
   secondarylib,
-  socrataHttpCuratorBroker
+  socrataHttpCuratorBroker,
+  soqlUtils
 )
 
 assembly/test := {}

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -190,9 +190,9 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
   def newQuery(req: HttpRequest): HttpResponse = {
     val rs = req.resourceScope
 
-    val analyzer2.Deserializer.Request(analysis, systemContext, passes) = analyzer2.Deserializer(req.inputStream)
+    val parsed = analyzer2.Deserializer(req.inputStream)
 
-    analyzer2.ProcessQuery(analysis, systemContext, passes, openPgu(dsInfo, None, rs), req.precondition, rs)
+    analyzer2.ProcessQuery(parsed, openPgu(dsInfo, None, rs), req.precondition, rs)
   }
 
   def etagFromCopy(datasetInternalName: String, copy: CopyInfo, etagInfo: Option[String], debug: Boolean = false): EntityTag = {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Deserializer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Deserializer.scala
@@ -5,12 +5,14 @@ import java.io.InputStream
 import com.socrata.soql.analyzer2.SoQLAnalysis
 import com.socrata.soql.analyzer2.rewrite.Pass
 import com.socrata.soql.serialize.{ReadBuffer, Readable}
+import com.socrata.soql.sql.Debug
 
 object Deserializer extends {
   case class Request(
     analysis: SoQLAnalysis[InputMetaTypes],
     context: Map[String, String],
-    passes: Seq[Seq[Pass]]
+    passes: Seq[Seq[Pass]],
+    debug: Option[Debug]
   )
   object Request {
     implicit def deserialize(implicit ev: Readable[SoQLAnalysis[InputMetaTypes]]) = new Readable[Request] {
@@ -20,7 +22,8 @@ object Deserializer extends {
             Request(
               buffer.read[SoQLAnalysis[InputMetaTypes]](),
               buffer.read[Map[String, String]](),
-              buffer.read[Seq[Seq[Pass]]]()
+              buffer.read[Seq[Seq[Pass]]](),
+              buffer.read[Option[Debug]]()
             )
           case other =>
             throw new Exception(s"Unknown request version $other")


### PR DESCRIPTION
The big change here is a rework of how processing the resultset works. It's now converted into an iterator of rows so that the inhibitRow option can just provide an empty iterator, so various bookeeping things that happened later before now happen earlier.