### PR TITLE
EN-60548: Fake-locations on the new query path

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
@@ -37,7 +37,7 @@ class SoQLFunctionSqlizerTest extends FunSuite with MustMatchers with SqlizerUni
 
     val cryptProvider = obfuscation.CryptProvider.zeros
 
-    override val repFor = new SoQLRepProvider[TestMT](_ => Some(cryptProvider), namespace) {
+    override val repFor = new SoQLRepProvider[TestMT](_ => Some(cryptProvider), namespace, Map.empty, Map.empty) {
       def mkStringLiteral(s: String) = Doc(JString(s).toString)
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.12.12"
+    val soqlStdlib = "4.12.13"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "4.2.7"
     val typesafeScalaLogging = "3.9.2"

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Deserializer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Deserializer.scala
@@ -2,25 +2,34 @@ package com.socrata.pg.server.analyzer2
 
 import java.io.InputStream
 
-import com.socrata.soql.analyzer2.SoQLAnalysis
+import com.socrata.datacoordinator.id.{DatasetInternalName, UserColumnId}
+
+import com.socrata.soql.analyzer2.{SoQLAnalysis, LabelUniverse}
 import com.socrata.soql.analyzer2.rewrite.Pass
 import com.socrata.soql.serialize.{ReadBuffer, Readable}
 import com.socrata.soql.sql.Debug
 
-object Deserializer extends {
+object Deserializer extends LabelUniverse[InputMetaTypes] {
   case class Request(
     analysis: SoQLAnalysis[InputMetaTypes],
+    locationSubcolumns: Map[DatabaseTableName, Map[DatabaseColumnName, Seq[Option[DatabaseColumnName]]]],
     context: Map[String, String],
     passes: Seq[Seq[Pass]],
     debug: Option[Debug]
   )
   object Request {
-    implicit def deserialize(implicit ev: Readable[SoQLAnalysis[InputMetaTypes]]) = new Readable[Request] {
+    implicit def deserialize(
+      implicit ev1: Readable[SoQLAnalysis[InputMetaTypes]],
+      ev2: Readable[DatasetInternalName],
+      ev3: Readable[UserColumnId],
+      ev4: Readable[Stage],
+    ) = new Readable[Request] {
       def readFrom(buffer: ReadBuffer): Request = {
         buffer.read[Int]() match {
           case 0 =>
             Request(
               buffer.read[SoQLAnalysis[InputMetaTypes]](),
+              buffer.read[Map[DatabaseTableName, Map[DatabaseColumnName, Seq[Option[DatabaseColumnName]]]]](),
               buffer.read[Map[String, String]](),
               buffer.read[Seq[Seq[Pass]]](),
               buffer.read[Option[Debug]]()


### PR DESCRIPTION
Plumb the subcolumn info from upstream into the SoQLRepProvider so that SoQLLocation can select them into the normal compound column intermediate format.

The "specialness" of this is pretty nicely kept to a minimum - the subcolumn info needs to get passed into the soql rep provider, and we need to keep track of what table labels refer to what physical database tables, but other than that all the weirdness of fake-locations is managed entirely within SoQLLocation's Rep implementation.