### PR TITLE
EN-60643: Citus distribution column shim

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
@@ -4,6 +4,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <changeSet author="Paul Maksimovich" id="20230620-citus-distribution-shim-create-table">
+        <preConditions onFail="MARK_RAN">
+            <customPrecondition className="com.socrata.util.Citus.MaybeDistribute.CitusPrecondition"/>
+        </preConditions>
         <sql>
             create table citus_distribution_map
             (

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
@@ -3,12 +3,12 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-    <changeSet author="Paul Maksimovich" id="20230620-citus-distribution-shim-create-table">
+    <changeSet author="Paul Maksimovich" id="20230620-citus-distribution-shim-create-dataset-table">
         <preConditions onFail="MARK_RAN">
             <customPrecondition className="com.socrata.util.Citus.MaybeDistribute.CitusPrecondition"/>
         </preConditions>
         <sql>
-            create table citus_distribution_map
+            create table citus_dataset_distribution_map
             (
               resource_name varchar(128) primary key,
               column_name text not null
@@ -16,7 +16,26 @@
         </sql>
         <rollback>
             <sql>
-                drop table citus_distribution_map;
+                drop table citus_dataset_distribution_map;
+            </sql>
+        </rollback>
+    </changeSet>
+    <changeSet author="Paul Maksimovich" id="20230620-citus-distribution-shim-create-rollup-table">
+        <preConditions onFail="MARK_RAN">
+            <customPrecondition className="com.socrata.util.Citus.MaybeDistribute.CitusPrecondition"/>
+        </preConditions>
+        <sql>
+            create table citus_rollup_distribution_map
+            (
+                resource_name varchar(128) not null,
+                rollup_name varchar not null,
+                column_name text not null,
+                unique (resource_name,rollup_name)
+            );
+        </sql>
+        <rollback>
+            <sql>
+                drop table citus_rollup_distribution_map;
             </sql>
         </rollback>
     </changeSet>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Paul Maksimovich" id="20230620-citus-distribution-shim-create-table">
+        <sql>
+            create table citus_distribution_map
+            (
+              resource_name varchar(128) primary key,
+              column_name text not null
+            );
+        </sql>
+        <rollback>
+            <sql>
+                drop table citus_distribution_map;
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -35,4 +35,5 @@
     <include file="com/socrata/pg/store/schema/20221116-create-rollup-table-name-seq.xml"/>
     <include file="com/socrata/pg/store/schema/20230607-create-jsonb-aggregates.xml"/>
     <include file="com/socrata/pg/store/schema/20230619-add-discrete-median-function.xml"/>
+    <include file="com/socrata/pg/store/schema/20230620-citus-distribution-shim.xml" />
 </databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
@@ -31,7 +31,7 @@ import com.socrata.pg.query.QueryServerHelper
 import com.socrata.soql.ast.{JoinFunc, JoinQuery, JoinTable, Select}
 import com.socrata.soql.parsing.StandaloneParser
 import com.socrata.soql.typed.Qualifier
-import com.socrata.util.Timing
+import com.socrata.util.{Citus, Timing}
 
 import java.time.{Clock, LocalDateTime, ZoneId}
 
@@ -252,7 +252,11 @@ class RollupManager(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: Cop
            "shapeVersion" -> copyInfo.dataShapeVersion,
            "rollupName" -> rollupInfo.name.underlying,
            "sql" -> createSql) {
-        stmt.execute(createSql + ChangeOwner.sql(pgu.conn, rollupInfo.tableName))
+        stmt.execute(
+          createSql +
+            ChangeOwner.sql(pgu.conn, rollupInfo.tableName) +
+            Citus.MaybeDistribute.sql(pgu.conn,copyInfo.datasetInfo.resourceName,rollupInfo.tableName,rollupInfo.name).getOrElse("")
+        )
         // sadly the COMMENT statement can't use prepared statement params...
         val commentSql = s"COMMENT ON TABLE ${rollupInfo.tableName} IS '" +
           SqlUtils.escapeString(pgu.conn, rollupInfo.name.underlying + " = " + rollupInfo.soql) + "'"

--- a/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
@@ -47,7 +47,7 @@ class SecondarySchemaLoader[CT, CV](conn: Connection, dsLogger: Logger[CT, CV],
       stmt.execute(
         "CREATE TABLE " + copyInfo.dataTableName + " ()" + tablespaceSqlPart(ts) + ";" +
           ChangeOwner.sql(conn, copyInfo.dataTableName) +
-          Citus.MaybeDistribute.sql(conn,copyInfo.datasetInfo.resourceName,copyInfo.dataTableName)
+          Citus.MaybeDistribute.sql(conn,copyInfo.datasetInfo.resourceName,copyInfo.dataTableName).getOrElse("")
       )
     }
     dsLogger.workingCopyCreated(copyInfo)

--- a/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
@@ -1,4 +1,4 @@
-package com.socrata.pg.store
+git package com.socrata.pg.store
 
 import com.rojoma.simplearm.v2._
 import com.socrata.datacoordinator.truth.loader.sql.{ChangeOwner, RepBasedPostgresSchemaLoader}
@@ -16,7 +16,8 @@ import com.rojoma.json.v3.ast.{JBoolean, JObject}
 import com.rojoma.json.v3.util.JsonUtil
 import com.socrata.datacoordinator.id.DatasetId
 import com.socrata.datacoordinator.util.TimingReport
-import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.environment.{ColumnName, ResourceName}
+import com.socrata.util.Citus
 
 class SecondarySchemaLoader[CT, CV](conn: Connection, dsLogger: Logger[CT, CV],
                                     repFor: ColumnInfo[CT] => SqlColumnRep[CT, CV] with Indexable[CT],
@@ -43,8 +44,11 @@ class SecondarySchemaLoader[CT, CV](conn: Connection, dsLogger: Logger[CT, CV],
     val ts: Option[String] = tablespace(copyInfo.dataTableName)
 
     using(conn.createStatement()) { stmt =>
-      stmt.execute("CREATE TABLE " + copyInfo.dataTableName + " ()" + tablespaceSqlPart(ts) + ";" +
-                   ChangeOwner.sql(conn, copyInfo.dataTableName))
+      stmt.execute(
+        "CREATE TABLE " + copyInfo.dataTableName + " ()" + tablespaceSqlPart(ts) + ";" +
+          ChangeOwner.sql(conn, copyInfo.dataTableName) +
+          Citus.MaybeDistribute.sql(conn,copyInfo.datasetInfo.resourceName,copyInfo.dataTableName).getOrElse("")
+      )
     }
     dsLogger.workingCopyCreated(copyInfo)
   }

--- a/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
@@ -47,7 +47,7 @@ class SecondarySchemaLoader[CT, CV](conn: Connection, dsLogger: Logger[CT, CV],
       stmt.execute(
         "CREATE TABLE " + copyInfo.dataTableName + " ()" + tablespaceSqlPart(ts) + ";" +
           ChangeOwner.sql(conn, copyInfo.dataTableName) +
-          Citus.MaybeDistribute.sql(conn,copyInfo.datasetInfo.resourceName,copyInfo.dataTableName).getOrElse("")
+          Citus.MaybeDistribute.sql(conn,copyInfo.datasetInfo.resourceName,copyInfo.dataTableName)
       )
     }
     dsLogger.workingCopyCreated(copyInfo)

--- a/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SecondarySchemaLoader.scala
@@ -1,4 +1,4 @@
-git package com.socrata.pg.store
+package com.socrata.pg.store
 
 import com.rojoma.simplearm.v2._
 import com.socrata.datacoordinator.truth.loader.sql.{ChangeOwner, RepBasedPostgresSchemaLoader}

--- a/common-pg/src/main/scala/com/socrata/util/Citus.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Citus.scala
@@ -22,9 +22,9 @@ object Citus {
         resourceNameOptional.flatMap { resourceName =>
           generate(conn, new ResourceName(resourceName), TableName(tableName)) match {
             case Left(x@Some(_)) => x
-            case Left(None) => log.info("No distribution key configured for %s", resourceName)
+            case Left(None) => log.info("No distribution key configured for dataset '%s'", resourceName)
               None
-            case Right(e) => log.error("Error while determining citus distribution key for dataset %s".format(resourceName), e)
+            case Right(e) => log.error("Error while determining citus distribution key for dataset '%s'".format(resourceName), e)
               None
           }
         }

--- a/common-pg/src/main/scala/com/socrata/util/Citus.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Citus.scala
@@ -21,101 +21,92 @@ object Citus {
 
   object MaybeDistribute {
 
-    def sql(conn: Connection, resourceNameOptional: Option[String], tableName: String): Option[String] = {
+    def sql(conn: Connection, resourceNameOptional: Option[String], tableName: String): Option[String] =
       resourceNameOptional.flatMap { resourceName =>
         sql(conn, new ResourceName(resourceName), TableName(tableName))
       }
-    }
 
-    def sql(conn: Connection, resourceName: ResourceName, tableName: TableName): Option[String] = {
+
+    def sql(conn: Connection, resourceName: ResourceName, tableName: TableName): Option[String] =
       if (shouldUseCitusDistribution) {
         generate(conn, resourceName, tableName) match {
-          case Left(x@Some(_)) => x
-          case Left(None) => log.info("No distribution key configured for dataset '%s'", resourceName.name)
+          case Right(x@Some(_)) => x
+          case Right(None) =>
+            log.info("No distribution key configured for dataset '%s'", resourceName.name)
             None
-          case Right(e) => log.error("Error while determining citus distribution key for dataset '%s'".format(resourceName.name), e)
+          case Left(e) =>
+            log.error("Error while determining citus distribution key for dataset '%s'".format(resourceName.name), e)
             None
         }
       } else {
         None
       }
-    }
 
-    def shouldUseCitusDistribution: Boolean = {
-      isCitus
-    }
 
-    def isCitus: Boolean = {
-      sys.env.get(IS_CITUS).exists { raw => raw.toBoolean }
-    }
+    def shouldUseCitusDistribution: Boolean = isCitus
 
-    private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName): Either[Option[String], SQLException] = {
+
+    def isCitus: Boolean = sys.env.get(IS_CITUS).exists { raw => raw.toBoolean }
+
+    private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName): Either[SQLException, Option[String]] =
       getDistributionColumnOfDataset(conn, resourceName) match {
-        case Left(Some(columnName)) => Left(Some("select create_distributed_table('%s', '%s');".format(tableName, columnName)))
-        case x@_ => x
+        case Right(Some(columnName)) => Right(Some("select create_distributed_table('%s', '%s');".format(tableName, columnName)))
+        case other => other
       }
-    }
 
-    private def getDistributionColumnOfDataset(conn: Connection, resourceName: ResourceName): Either[Option[String], SQLException] = {
+    private def getDistributionColumnOfDataset(conn: Connection, resourceName: ResourceName): Either[SQLException, Option[String]] =
       using(conn.prepareStatement("select column_name from citus_dataset_distribution_map where resource_name=?")) { stmt =>
         stmt.setString(1, resourceName.name)
         extractCitusDistributionColumnName(stmt.executeQuery())
       }
-    }
 
-    private def extractCitusDistributionColumnName(rs: ResultSet): Either[Option[String], SQLException] = {
+    private def extractCitusDistributionColumnName(rs: ResultSet): Either[SQLException, Option[String]] =
       try {
         if (rs.next()) {
-          Left(Some(rs.getString("column_name")))
+          Right(Some(rs.getString("column_name")))
         } else {
-          Left(None)
+          Right(None)
         }
       } catch {
-        case e: SQLException => Right(e)
+        case e: SQLException => Left(e)
       }
-    }
 
-    def sql(conn: Connection, resourceNameOptional: Option[String], tableName: String, rollupName: RollupName): Option[String] = {
+    def sql(conn: Connection, resourceNameOptional: Option[String], tableName: String, rollupName: RollupName): Option[String] =
       resourceNameOptional.flatMap { resourceName =>
         sql(conn, new ResourceName(resourceName), TableName(tableName), rollupName)
       }
-    }
 
-    def sql(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Option[String] = {
+    def sql(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Option[String] =
       if (shouldUseCitusDistribution) {
         generate(conn, resourceName, tableName, rollupName) match {
-          case Left(x@Some(_)) => x
-          case Left(None) => log.info("No distribution key configured for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying))
+          case Right(x@Some(_)) => x
+          case Right(None) =>
+            log.info("No distribution key configured for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying))
             None
-          case Right(e) => log.error("Error while determining citus distribution key for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying), e)
+          case Left(e) =>
+            log.error("Error while determining citus distribution key for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying), e)
             None
         }
       } else {
         None
       }
-    }
 
-    private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Either[Option[String], SQLException] = {
+    private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Either[SQLException, Option[String]] =
       getDistributionColumnOfRollup(conn, resourceName, rollupName) match {
-        case Left(Some(columnName)) => Left(Some("select create_distributed_table('%s', '%s');".format(tableName, columnName)))
-        case x@_ => x
+        case Right(Some(columnName)) => Right(Some("select create_distributed_table('%s', '%s');".format(tableName, columnName)))
+        case other => other
       }
-    }
 
-    private def getDistributionColumnOfRollup(conn: Connection, resourceName: ResourceName, rollupName: RollupName): Either[Option[String], SQLException] = {
+    private def getDistributionColumnOfRollup(conn: Connection, resourceName: ResourceName, rollupName: RollupName): Either[SQLException, Option[String]] =
       using(conn.prepareStatement("select column_name from citus_rollup_distribution_map where resource_name=? and rollup_name=?")) { stmt =>
         stmt.setString(1, resourceName.name)
         stmt.setString(2, rollupName.underlying)
         extractCitusDistributionColumnName(stmt.executeQuery())
       }
-    }
 
     class CitusPrecondition extends CustomPrecondition {
-      override def check(database: Database): Unit = {
-        if (!isCitus) {
-          throw new CustomPreconditionFailedException("Not a citus node")
-        }
-      }
+      override def check(database: Database): Unit =
+        if (!isCitus) { throw new CustomPreconditionFailedException("Not a citus node") }
     }
   }
 }

--- a/common-pg/src/main/scala/com/socrata/util/Citus.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Citus.scala
@@ -1,6 +1,7 @@
 package com.socrata.util
 
 import com.rojoma.simplearm.v2.using
+import com.socrata.datacoordinator.id.RollupName
 import com.socrata.soql.environment.{ResourceName, TableName}
 import com.socrata.util.Citus.Constant.IS_CITUS
 import liquibase.database.Database
@@ -30,9 +31,9 @@ object Citus {
       if (shouldUseCitusDistribution) {
         generate(conn, resourceName, tableName) match {
           case Left(x@Some(_)) => x
-          case Left(None) => log.info("No distribution key configured for dataset '%s'", resourceName)
+          case Left(None) => log.info("No distribution key configured for dataset '%s'", resourceName.name)
             None
-          case Right(e) => log.error("Error while determining citus distribution key for dataset '%s'".format(resourceName), e)
+          case Right(e) => log.error("Error while determining citus distribution key for dataset '%s'".format(resourceName.name), e)
             None
         }
       } else {
@@ -40,12 +41,12 @@ object Citus {
       }
     }
 
-    def isCitus: Boolean = {
-      sys.env.get(IS_CITUS).exists { raw => raw.toBoolean }
-    }
-
     def shouldUseCitusDistribution: Boolean = {
       isCitus
+    }
+
+    def isCitus: Boolean = {
+      sys.env.get(IS_CITUS).exists { raw => raw.toBoolean }
     }
 
     private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName): Either[Option[String], SQLException] = {
@@ -56,7 +57,7 @@ object Citus {
     }
 
     private def getDistributionColumnOfDataset(conn: Connection, resourceName: ResourceName): Either[Option[String], SQLException] = {
-      using(conn.prepareStatement("select column_name from citus_distribution_map where resource_name=?")) { stmt =>
+      using(conn.prepareStatement("select column_name from citus_dataset_distribution_map where resource_name=?")) { stmt =>
         stmt.setString(1, resourceName.name)
         extractCitusDistributionColumnName(stmt.executeQuery())
       }
@@ -74,9 +75,44 @@ object Citus {
       }
     }
 
-    class CitusPrecondition extends CustomPrecondition{
+    def sql(conn: Connection, resourceNameOptional: Option[String], tableName: String, rollupName: RollupName): Option[String] = {
+      resourceNameOptional.flatMap { resourceName =>
+        sql(conn, new ResourceName(resourceName), TableName(tableName), rollupName)
+      }
+    }
+
+    def sql(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Option[String] = {
+      if (shouldUseCitusDistribution) {
+        generate(conn, resourceName, tableName, rollupName) match {
+          case Left(x@Some(_)) => x
+          case Left(None) => log.info("No distribution key configured for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying))
+            None
+          case Right(e) => log.error("Error while determining citus distribution key for dataset '%s', rollup '%s'".format(resourceName.name, rollupName.underlying), e)
+            None
+        }
+      } else {
+        None
+      }
+    }
+
+    private def generate(conn: Connection, resourceName: ResourceName, tableName: TableName, rollupName: RollupName): Either[Option[String], SQLException] = {
+      getDistributionColumnOfRollup(conn, resourceName, rollupName) match {
+        case Left(Some(columnName)) => Left(Some("select create_distributed_table('%s', '%s');".format(tableName, columnName)))
+        case x@_ => x
+      }
+    }
+
+    private def getDistributionColumnOfRollup(conn: Connection, resourceName: ResourceName, rollupName: RollupName): Either[Option[String], SQLException] = {
+      using(conn.prepareStatement("select column_name from citus_rollup_distribution_map where resource_name=? and rollup_name=?")) { stmt =>
+        stmt.setString(1, resourceName.name)
+        stmt.setString(2, rollupName.underlying)
+        extractCitusDistributionColumnName(stmt.executeQuery())
+      }
+    }
+
+    class CitusPrecondition extends CustomPrecondition {
       override def check(database: Database): Unit = {
-        if(!isCitus){
+        if (!isCitus) {
           throw new CustomPreconditionFailedException("Not a citus node")
         }
       }

--- a/common-pg/src/main/scala/com/socrata/util/Citus.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Citus.scala
@@ -1,0 +1,47 @@
+package com.socrata.util
+
+import com.rojoma.simplearm.v2.using
+import com.socrata.soql.environment.{ResourceName, TableName}
+import com.socrata.util.Citus.Constant.IS_CITUS
+
+import java.sql.{Connection, ResultSet}
+
+object Citus {
+
+  private def distributeTable(conn: Connection, resourceName: ResourceName, tableName: TableName): String = {
+    "select create_distributed_table('%s', '%s');".format(tableName, getDistributionColumnOfDataset(conn, resourceName))
+  }
+
+  private def getDistributionColumnOfDataset(conn: Connection, resourceName: ResourceName): Option[String] = {
+    using(conn.prepareStatement("select column_name from citus_distribution_map where resource_name=?")) { stmt =>
+      stmt.setString(1, resourceName.name)
+      extractCitusDistributionColumnName(stmt.executeQuery())
+    }
+  }
+
+  private def extractCitusDistributionColumnName(rs: ResultSet): Option[String] = {
+    if (rs.next()) {
+      Some(rs.getString("column_name"))
+    } else {
+      None
+    }
+  }
+
+  object Constant {
+    val IS_CITUS = "IS_CITUS"
+  }
+
+  def shouldUseCitusDistribution: Boolean = {
+    sys.env.contains(IS_CITUS)
+  }
+
+  object MaybeDistribute {
+    def sql(conn: Connection, resourceName: Option[String], tableName: String): Option[String] = {
+      if (shouldUseCitusDistribution) {
+        resourceName.map { resource => Citus.distributeTable(conn, new ResourceName(resource), TableName(tableName)) }
+      } else {
+        None
+      }
+    }
+  }
+}

--- a/common-pg/src/main/scala/com/socrata/util/Citus.scala
+++ b/common-pg/src/main/scala/com/socrata/util/Citus.scala
@@ -12,7 +12,7 @@ object Citus {
   val log: Logger = org.slf4j.LoggerFactory.getLogger(Citus.getClass)
 
   def shouldUseCitusDistribution: Boolean = {
-    sys.env.contains(IS_CITUS)
+    sys.env.get(IS_CITUS).map{raw=>}.getOrElse(false)
   }
 
   private def distributeTable(conn: Connection, resourceName: ResourceName, tableName: TableName): Option[String] = {


### PR DESCRIPTION
This introduces a shim for letting Citus determine what column of a dataset to use for distribution.
The intention is for this to be temporary while we test Citus in a controlled environment.

The shim is implemented via a lookup table named `citus_dataset_distribution_map` and `citus_rollup_distribution_map`.
There are two places where a dataset table gets created currently:
- SecondarySchemaLoader#create
- com.socrata.pg.store.RollupManager#createRollupTable
