### PR TITLE
Make fake-location human_address serialization work _exactly_ in v1 a…

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20230630-make-human-address-like-old.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20230630-make-human-address-like-old.xml
@@ -1,0 +1,39 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="robertm" id="20230626-nontrivial-soql-functions" runOnChange="true">
+        <sql splitStatements="false"><![CDATA[
+          CREATE OR REPLACE FUNCTION soql_to_jsonb_empty(string text) RETURNS jsonb AS $$
+            select to_jsonb(coalesce(string, ''));
+          $$ LANGUAGE SQL
+          IMMUTABLE
+          PARALLEL SAFE;
+
+          CREATE OR REPLACE FUNCTION soql_human_address(address text, city text, state text, zip text) RETURNS text AS $$
+            select case when address is null and city is null and state is null and zip is null then
+                     null
+                   else
+                     '{"address": ' || soql_to_jsonb_empty(address)::text || ', "city": ' || soql_to_jsonb_empty(city)::text || ', "state": ' || soql_to_jsonb_empty(state)::text || ', "zip": ' || soql_to_jsonb_empty(zip)::text || '}'
+                   end;
+          $$ LANGUAGE SQL
+          IMMUTABLE
+          PARALLEL SAFE;
+        ]]></sql>
+        <rollback>
+            <sql splitStatements="false"><![CDATA[
+              CREATE OR REPLACE FUNCTION soql_human_address(address text, city text, state text, zip text) RETURNS text AS $$
+                select case when address is null and city is null and state is null and zip is null then
+                         null
+                       else
+                         '{"address":' || soql_to_jsonb_null(address)::text || ',"city":' || soql_to_jsonb_null(city)::text || ',"state":' || soql_to_jsonb_null(state)::text || ',"zip":' || soql_to_jsonb_null(zip)::text || '}'
+                       end;
+              $$ LANGUAGE SQL
+              IMMUTABLE
+              PARALLEL SAFE;
+
+              DROP FUNCTION soql_to_jsonb_empty(text);
+            ]]></sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/migrate.xml
@@ -37,4 +37,5 @@
     <include file="com/socrata/pg/store/schema/20230619-add-discrete-median-function.xml"/>
     <include file="com/socrata/pg/store/schema/20230626-nontrivial-soql-functions.xml"/>
     <include file="com/socrata/pg/store/schema/20230626-soql-compress-compound.xml"/>
+    <include file="com/socrata/pg/store/schema/20230630-make-human-address-like-old.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
…nd v2

Specifically, this produces a string containing a JSON blob, and v2 was different in two respects:
 * null subcolumns serialize as empty strings (:crying_cat_face:)
 * minor whitespace differences