### PR TITLE
Some cleanups that came out of the temp view experiment

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/Rep.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/Rep.scala
@@ -145,7 +145,7 @@ object Rep {
         // literal by SQL's standards.  Otherwise this will have
         // trouble if you order or group by :id
         val dsTable = namespace.tableLabel(col.table)
-        ExprSql.Expanded[MT](Seq(mkStringLiteral(col.tableCanonicalName.name) +#+ d":: text", dsTable ++ d"." ++ compressedDatabaseColumn(col.column)), col)
+        ExprSql.Expanded[MT](Seq(mkTextLiteral(col.tableCanonicalName.name), dsTable ++ d"." ++ compressedDatabaseColumn(col.column)), col)
       }
 
       def virtualColumnRef(col: VirtualColumn, isExpanded: Boolean) = {

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SqlizerTest.scala
@@ -200,7 +200,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "select :id from @table1 where :id = 'row-qwer-tyui-2345'"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 WHERE (x1.:id) = (1200459281559959 :: bigint)")
+    sqlish must equal ("SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 WHERE (x1.:id) = (1200459281559959 :: bigint)")
   }
 
   test("provenance - joined") {
@@ -215,7 +215,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "select :id from @table1 join @table2 on @table1.:id = @table2.:id"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 JOIN table2 AS x2 ON ((\"table1\" :: text) IS NOT DISTINCT FROM (\"table2\" :: text)) AND ((x1.:id) = (x2.:id))")
+    sqlish must equal ("SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 JOIN table2 AS x2 ON ((text \"table1\") IS NOT DISTINCT FROM (text \"table2\")) AND ((x1.:id) = (x2.:id))")
   }
 
   test("provenance - compressed") {
@@ -227,7 +227,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "select :id from @table1 where :id = compress('row-qwer-tyui-2345')"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 WHERE (soql_compress_compound(\"table1\" :: text, x1.:id)) = (soql_compress_compound(\"table1\" :: text, 1200459281559959 :: bigint))")
+    sqlish must equal ("SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 WHERE (soql_compress_compound(text \"table1\", x1.:id)) = (soql_compress_compound(text \"table1\", 1200459281559959 :: bigint))")
   }
 
   test("provenance - order by physical column does not include the provenance") {
@@ -239,7 +239,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "select :id from @table1 order by :id"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 ORDER BY x1.:id ASC NULLS LAST")
+    sqlish must equal ("SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1 ORDER BY x1.:id ASC NULLS LAST")
   }
 
   test("provenance - order by simple logical column does not include the provenance") {
@@ -251,7 +251,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "select :id from @table1 |> select :id order by :id"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT x2.i1_provenance AS i2_provenance, x2.i1 AS i2 FROM (SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1) AS x2 ORDER BY x2.i1 ASC NULLS LAST")
+    sqlish must equal ("SELECT x2.i1_provenance AS i2_provenance, x2.i1 AS i2 FROM (SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1) AS x2 ORDER BY x2.i1 ASC NULLS LAST")
   }
 
   test("provenance - order by unioned logical column DOES include the provenance") {
@@ -266,7 +266,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
 
     val soql = "(select :id from @table1 union select :id from @table2) |> select :id order by :id"
     val sqlish = analyze(tf, soql).layoutSingleLine.toString
-    sqlish must equal ("SELECT x5.i1_provenance AS i3_provenance, x5.i1 AS i3 FROM ((SELECT \"table1\" :: text AS i1_provenance, x1.:id AS i1 FROM table1 AS x1) UNION (SELECT \"table2\" :: text AS i2_provenance, x3.:id AS i2 FROM table2 AS x3)) AS x5 ORDER BY x5.i1_provenance ASC NULLS LAST, x5.i1 ASC NULLS LAST")
+    sqlish must equal ("SELECT x5.i1_provenance AS i3_provenance, x5.i1 AS i3 FROM ((SELECT text \"table1\" AS i1_provenance, x1.:id AS i1 FROM table1 AS x1) UNION (SELECT text \"table2\" AS i2_provenance, x3.:id AS i2 FROM table2 AS x3)) AS x5 ORDER BY x5.i1_provenance ASC NULLS LAST, x5.i1 ASC NULLS LAST")
   }
 
 

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/TestRepProvider.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/TestRepProvider.scala
@@ -27,7 +27,7 @@ class TestRepProvider(override val namespace: SqlNamespaces[SqlizerTest.TestMT])
 
         val provLit = rawId.provenance match {
           case None => d"null :: text"
-          case Some(s) => mkStringLiteral(s) +#+ d":: text"
+          case Some(s) => mkTextLiteral(s)
         }
         val numLit = Doc(rawId.value) +#+ d":: bigint"
 
@@ -45,7 +45,7 @@ class TestRepProvider(override val namespace: SqlNamespaces[SqlizerTest.TestMT])
     TestText -> new SingleColumnRep(TestText, d"text") {
       def literal(e: LiteralValue) = {
         val TestText(s) = e.value
-        ExprSql(mkStringLiteral(s), e)
+        ExprSql(mkTextLiteral(s), e)
       }
       protected def doExtractFrom(rs: ResultSet, dbCol: Int): CV = {
         ???
@@ -92,7 +92,7 @@ class TestRepProvider(override val namespace: SqlNamespaces[SqlizerTest.TestMT])
             ExprSql.Expanded[TestMT](Seq(d"null :: text", d"null :: numeric"), e)
           case TestCompound(a, b) =>
             val aLit = a match {
-              case Some(n) => mkStringLiteral(n)
+              case Some(n) => mkTextLiteral(n)
               case None => d"null :: text"
             }
             val bLit = b match {


### PR DESCRIPTION
* text literal sql is now more consistently `text 'foo'` rather than `'foo' :: text` or just `'foo'`
* Some places where we were using mkStringLiteral are now mkTextLiteral
* Debug info (most importantly "explain"!) is done after doing the etag precondition check insetad of before.