### PR TITLE
Stream results from the database

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/Rep.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/Rep.scala
@@ -26,6 +26,16 @@ trait Rep[MT <: MetaTypes] extends ExpressionUniverse[MT] {
   def isProvenanced: Boolean = false
   def provenanceOf(value: LiteralValue): Set[CanonicalName]
 
+  // Postgresql's JDBC driver will read rows in fixed-size blocks; by
+  // default, it reads all the results into memory before returning
+  // them. You can make it stream by setting the fetch size (in rows),
+  // so we'll do that.
+  // Specifically, we'll set the fetch size based on the types of
+  // columns in the result - in particular geo types routinely use a
+  // lot of memory, so we'll consider such types as being "large" and
+  // set a small fetch size when one exists in the result.
+  def isPotentiallyLarge: Boolean = false
+
   // throws an exception if "field" is not a subcolumn of this type
   def subcolInfo(field: String): SubcolInfo[MT]
 

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/ResultExtractor.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/ResultExtractor.scala
@@ -7,7 +7,10 @@ import java.sql.ResultSet
 import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.analyzer2._
 
-class ResultExtractor[MT <: MetaTypes](rawSchema: OrderedMap[types.ColumnLabel[MT], AugmentedType[MT]], repFor: Rep.Provider[MT])(implicit tag: ClassTag[MT#ColumnValue]) extends SqlizerUniverse[MT] {
+class ResultExtractor[MT <: MetaTypes](
+  rawSchema: OrderedMap[types.ColumnLabel[MT], AugmentedType[MT]],
+  repFor: Rep.Provider[MT]
+)(implicit tag: ClassTag[MT#ColumnValue]) extends SqlizerUniverse[MT] {
   private val extractors = rawSchema.valuesIterator.map { case AugmentedType(typ, isExpanded) =>
     repFor(typ).extractFrom(isExpanded)
   }.toArray
@@ -30,4 +33,11 @@ class ResultExtractor[MT <: MetaTypes](rawSchema: OrderedMap[types.ColumnLabel[M
 
     result
   }
+
+  def fetchSize =
+    if(schema.valuesIterator.exists(repFor(_).isPotentiallyLarge)) {
+      10
+    } else {
+      1000
+    }
 }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLRep.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLRep.scala
@@ -281,18 +281,23 @@ abstract class SoQLRepProvider[MT <: MetaTypes with ({type ColumnType = SoQLType
     },
     SoQLMultiPoint -> new GeometryRep(SoQLMultiPoint, SoQLMultiPoint(_), "mpoint") {
       override def downcast(v: SoQLValue) = v.asInstanceOf[SoQLMultiPoint].value
+      override def isPotentiallyLarge = true
     },
     SoQLLine -> new GeometryRep(SoQLLine, SoQLLine(_), "line") {
       override def downcast(v: SoQLValue) = v.asInstanceOf[SoQLLine].value
+      override def isPotentiallyLarge = true
     },
     SoQLMultiLine -> new GeometryRep(SoQLMultiLine, SoQLMultiLine(_), "mline") {
       override def downcast(v: SoQLValue) = v.asInstanceOf[SoQLMultiLine].value
+      override def isPotentiallyLarge = true
     },
     SoQLPolygon -> new GeometryRep(SoQLPolygon, SoQLPolygon(_), "polygon") {
       override def downcast(v: SoQLValue) = v.asInstanceOf[SoQLPolygon].value
+      override def isPotentiallyLarge = true
     },
     SoQLMultiPolygon -> new GeometryRep(SoQLMultiPolygon, SoQLMultiPolygon(_), "mpoly") {
       override def downcast(v: SoQLValue) = v.asInstanceOf[SoQLMultiPolygon].value
+      override def isPotentiallyLarge = true
     },
 
     // COMPOUND REPS

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
@@ -293,6 +293,7 @@ object ProcessQuery {
 
     new Iterator[Array[JValue]] {
       private val stmt = rs.open(conn.createStatement())
+      stmt.setFetchSize(extractor.fetchSize)
       private val resultSet = rs.open(stmt.executeQuery(sql))
       private var done = false
       private var ready = false


### PR DESCRIPTION
Postgresql's JDBC driver will read rows in fixed-size blocks; by default, it reads _all_ the results into memory before returning them.  You can make it stream by setting the fetch size (in rows), so we'll do that.

Specifically, we'll set the fetch size based on the types of columns in the result - in particular geo types routinely use a lot of memory, so we'll consider such types as being "large" and set a small fetch size when one exists in the result.