### PR TITLE
EN-60871: Lock datasets involved in joins against concurrent updates

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.14.5"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "4.2.11"
+    val dataCoordinator = "4.2.13"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"

--- a/soql-server-pg/src/test/scala/com/socrata/pg/store/SchemaTest.scala
+++ b/soql-server-pg/src/test/scala/com/socrata/pg/store/SchemaTest.scala
@@ -19,7 +19,7 @@ class SchemaTest extends PGSecondaryTestBase with PGQueryServerDatabaseTestBase 
     ds.map { dsInfo =>
       withPgu() { pgu =>
       val f = columnsCreatedFixture
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
       val qs = new QueryServerTest(dsInfo, pgu)
       val schema = qs.getSchema(f.datasetInfo.internalName, None).get
       val schemaj = JsonUtil.renderJson(schema)

--- a/store-pg/src/main/scala/com/socrata/pg/store/WarnAfter.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/WarnAfter.scala
@@ -1,0 +1,25 @@
+package com.socrata.pg.store
+
+import scala.concurrent.duration.FiniteDuration
+
+import java.util.concurrent.{Semaphore, TimeUnit}
+
+import com.typesafe.scalalogging.Logger
+
+final class WarnAfter(duration: FiniteDuration, log: Logger, msg: String) extends Thread {
+  setName("lock timeout for " + Thread.currentThread.getName)
+  setDaemon(true)
+
+  val semaphore = new Semaphore(0)
+
+  override def run() {
+    if(!semaphore.tryAcquire(duration.toMillis, TimeUnit.MILLISECONDS)) {
+      log.warn(msg)
+    }
+  }
+
+  def completed() {
+    semaphore.release()
+    join()
+  }
+}

--- a/store-pg/src/test/scala/com/socrata/pg/store/CurrentCopyNumberTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/CurrentCopyNumberTest.scala
@@ -9,7 +9,7 @@ class CurrentCopyNumberTest extends PGSecondaryTestBase with PGSecondaryUniverse
     withPgu() { pgu =>
       val f = workingCopyCreatedFixture
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
 
       val actualCopyNum = f.pgs.doCurrentCopyNumber(pgu, f.datasetInfo.internalName, None)
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/CurrentVersionTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/CurrentVersionTest.scala
@@ -13,7 +13,7 @@ class CurrentVersionTest extends PGSecondaryTestBase with PGSecondaryUniverseTes
       var version = f.dataVersion
       f.events foreach { e =>
         version = version + 1
-        f.pgs.doVersion(pgu, f.datasetInfo, version, version, None, Iterator(e))
+        f.pgs.doVersion(pgu, f.datasetInfo, version, version, None, Iterator(e), Nil)
       }
 
       f.pgs.doCurrentVersion(pgu, f.datasetInfo.internalName, None) shouldEqual version
@@ -26,7 +26,7 @@ class CurrentVersionTest extends PGSecondaryTestBase with PGSecondaryUniverseTes
 
       var version = f.dataVersion
       f.events foreach { e =>
-        f.pgs.doVersion(pgu, f.datasetInfo, version + 1, version + 10, None, Iterator(e))
+        f.pgs.doVersion(pgu, f.datasetInfo, version + 1, version + 10, None, Iterator(e), Nil)
         version = version + 10
       }
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/IndexTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/IndexTest.scala
@@ -221,7 +221,7 @@ class IndexTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wit
       copyColumns(pgu, copyInfo, secondUnpublished,  200)
 
       val pgs = new PGSecondary(config)
-      pgs.doVersion(pgu, secDatasetInfo, secondUnpublished.dataVersion + 1, secondUnpublished.dataVersion + 1, None, Iterator(WorkingCopyDropped))
+      pgs.doVersion(pgu, secDatasetInfo, secondUnpublished.dataVersion + 1, secondUnpublished.dataVersion + 1, None, Iterator(WorkingCopyDropped), Nil)
 
       // Check that the index in the previous copy is still good.
       val previousCopy = getTruthCopyInfo(pgu, secDatasetInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapWriterTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/PGSecondaryDatasetMapWriterTest.scala
@@ -63,7 +63,7 @@ class PGSecondaryDatasetMapWriterTest extends PGSecondaryTestBase with PGSeconda
     withPgu() { pgu =>
       val f = columnsCreatedFixture
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
 

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -285,7 +285,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       createSystemColumns(pgu, secondCopy, 400)
 
       val pgs = new PGSecondary(config)
-      pgs.doVersion(pgu, datasetInfo, secondCopy.dataVersion + 1, secondCopy.dataVersion + 1, None, Iterator(WorkingCopyDropped))
+      pgs.doVersion(pgu, datasetInfo, secondCopy.dataVersion + 1, secondCopy.dataVersion + 1, None, Iterator(WorkingCopyDropped), Nil)
 
       // Check that the rollup in the previous copy is still good.
       val previousCopy = getTruthCopyInfo(pgu, datasetInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/ColumnCreatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/ColumnCreatedHandlerTest.scala
@@ -11,7 +11,7 @@ class ColumnCreatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUnive
     withPgu() { pgu =>
       val f = columnsCreatedFixture
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       val schema = pgu.datasetMapReader.schema(truthCopyInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/ColumnRemovedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/ColumnRemovedHandlerTest.scala
@@ -11,7 +11,7 @@ class ColumnRemovedHandlerTest extends PGSecondaryTestBase with PGSecondaryUnive
     withPgu() { pgu =>
       val f = columnsRemovedFixture
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       val schema = pgu.datasetMapReader.schema(truthCopyInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/FieldNameUpdatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/FieldNameUpdatedHandlerTest.scala
@@ -12,7 +12,7 @@ class FieldNameUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUn
     withPgu() { pgu =>
       val f = fieldNameUpdatedFixture
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       val schema = pgu.datasetMapReader.schema(truthCopyInfo)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/LastModifiedChangedTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/LastModifiedChangedTest.scala
@@ -18,7 +18,7 @@ class LastModifiedChangedTest extends PGSecondaryTestBase with PGSecondaryUniver
       val events = f.events ++ Seq(
         LastModifiedChanged(someRandomTime)
       )
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       truthCopyInfo.lastModified should be (someRandomTime)

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/RowDataUpdatedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/RowDataUpdatedHandlerTest.scala
@@ -48,7 +48,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
           RowDataUpdated(insertOps)
         )
 
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
         for {
           truthCopyInfo <- unmanaged(getTruthCopyInfo(pgu, f.datasetInfo))
@@ -66,9 +66,9 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
           RowDataUpdated(insertOpsLongString)
         )
 
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, f.events.iterator, Nil)
         intercept[ResyncSecondaryException] {
-          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, events.iterator)
+          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, events.iterator, Nil)
         }
     }
   }
@@ -81,7 +81,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
         val f = publishedDatasetFixture
         val events = f.events :+ RowDataUpdated(insertOps)
 
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
         val updateOps = Seq(
           (1000, 110, "bar"),
@@ -95,7 +95,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
 
         val updateEvents = Seq(RowDataUpdated(updateOps))
 
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, updateEvents.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, updateEvents.iterator, Nil)
 
         for {
           truthCopyInfo <- unmanaged(getTruthCopyInfo(pgu, f.datasetInfo))
@@ -113,7 +113,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
         val f = publishedDatasetFixture
         val events = f.events :+ RowDataUpdated(insertOps)
 
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
         val updateOps = Seq(
           (1000, 110, "bar"),
@@ -128,7 +128,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
         val updateEvents = Seq(RowDataUpdated(updateOps))
 
         intercept[ResyncSecondaryException] {
-          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, updateEvents.iterator)
+          f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, updateEvents.iterator, Nil)
         }
     }
   }
@@ -139,7 +139,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
       val f = publishedDatasetFixture
       val events = f.events :+ RowDataUpdated(insertOps)
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       val deleteOps = Seq(
         1000,
@@ -149,7 +149,7 @@ class RowDataUpdatedHandlerTest extends PGSecondaryTestBase with PGSecondaryUniv
 
       val deleteEvents = Seq(RowDataUpdated(deleteOps))
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, deleteEvents.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 2, f.dataVersion + 2, None, deleteEvents.iterator, Nil)
 
       for {
         truthCopyInfo <- unmanaged(getTruthCopyInfo(pgu, f.datasetInfo))

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/SystemRowIdentifierChangedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/SystemRowIdentifierChangedHandlerTest.scala
@@ -18,7 +18,7 @@ class SystemRowIdentifierChangedHandlerTest extends PGSecondaryTestBase with PGS
         ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None)),
         SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")),  SoQLID, false, false, false, None))
       )
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       val schema = pgu.datasetMapReader.schema(truthCopyInfo)
@@ -36,7 +36,7 @@ class SystemRowIdentifierChangedHandlerTest extends PGSecondaryTestBase with PGS
         SystemRowIdentifierChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":id")), SoQLID, false, false, false, None))
       )
       intercept[UnsupportedOperationException] {
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
       }
     }
   }

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/TruncateHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/TruncateHandlerTest.scala
@@ -29,7 +29,7 @@ class TruncateHandlerTest extends PGSecondaryTestBase with PGSecondaryUniverseTe
       val f = columnsCreatedFixture
       val events = f.events ++ Seq(RowDataUpdated(insertOps), Truncated)
 
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       for {
         truthCopyInfo <- unmanaged(getTruthCopyInfo(pgu, f.datasetInfo))

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/VersionColumnChangedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/VersionColumnChangedHandlerTest.scala
@@ -18,7 +18,7 @@ class VersionColumnChangedHandlerTest extends PGSecondaryTestBase with PGSeconda
         ColumnCreated(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLID, false, false, false, None)),
         VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":version"), Some(ColumnName(":version")), SoQLID, false, false, false, None))
       )
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
       val schema = pgu.datasetMapReader.schema(truthCopyInfo)
@@ -36,7 +36,7 @@ class VersionColumnChangedHandlerTest extends PGSecondaryTestBase with PGSeconda
         VersionColumnChanged(ColumnInfo(new ColumnId(9124), new UserColumnId(":id"), Some(ColumnName(":version")), SoQLID, false, false, false, None))
       )
       intercept[UnsupportedOperationException] {
-        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+        f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
       }
     }
   }

--- a/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyPublishedHandlerTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/events/WorkingCopyPublishedHandlerTest.scala
@@ -14,7 +14,7 @@ class WorkingCopyPublishedHandlerTest extends PGSecondaryTestBase with PGSeconda
       val events = f.events ++ Seq(
         WorkingCopyPublished
       )
-      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator)
+      f.pgs.doVersion(pgu, f.datasetInfo, f.dataVersion + 1, f.dataVersion + 1, None, events.iterator, Nil)
 
       val truthCopyInfo = getTruthCopyInfo(pgu, f.datasetInfo)
 


### PR DESCRIPTION
When performing a replication event, take locks so that concurrent updates on joined datasets always see a consistent view.