### PR TITLE
Search fixes

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/RewriteSearch.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/RewriteSearch.scala
@@ -108,8 +108,8 @@ abstract class RewriteSearch[MT <: MetaTypes]
       FunctionCall[MT](
         tsSearch,
         Seq(
-          FunctionCall[MT](toTsVector, Seq(litText("english"), haystack))(FuncallPositionInfo.None),
-          FunctionCall[MT](toTsQuery, Seq(litText("english"), needle))(FuncallPositionInfo.None)
+          FunctionCall[MT](toTsVector, Seq(haystack))(FuncallPositionInfo.None),
+          FunctionCall[MT](plainToTsQuery, Seq(needle))(FuncallPositionInfo.None)
         )
       )(FuncallPositionInfo.None)
     } else {
@@ -130,5 +130,5 @@ abstract class RewriteSearch[MT <: MetaTypes]
   protected def concat: MonomorphicFunction
   protected def tsSearch: MonomorphicFunction
   protected def toTsVector: MonomorphicFunction
-  protected def toTsQuery: MonomorphicFunction
+  protected def plainToTsQuery: MonomorphicFunction
 }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
@@ -502,8 +502,8 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with ({ type ColumnType = SoQLType; ty
       // magical
       GetContext -> sqlizeGetContext,
 
-      SoQLRewriteSearch.ToTsVector -> sqlizeNormalOrdinaryFuncall("to_tsvector"),
-      SoQLRewriteSearch.ToTsQuery -> sqlizeNormalOrdinaryFuncall("to_tsquery"),
+      SoQLRewriteSearch.ToTsVector -> sqlizeNormalOrdinaryFuncall("to_tsvector", prefixArgs = Seq(d"'english'")),
+      SoQLRewriteSearch.PlainToTsQuery -> sqlizeNormalOrdinaryFuncall("plainto_tsquery", prefixArgs = Seq(d"'english'")),
       SoQLRewriteSearch.TsSearch -> sqlizeBinaryOp("@@"),
 
       // simple casts

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLRewriteSearch.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLRewriteSearch.scala
@@ -49,7 +49,7 @@ class SoQLRewriteSearch[MT <: MetaTypes with ({type ColumnType = SoQLType; type 
   }
 
   override val toTsVector = SoQLRewriteSearch.ToTsVector.monomorphic.get
-  override val toTsQuery = SoQLRewriteSearch.ToTsQuery.monomorphic.get
+  override val plainToTsQuery = SoQLRewriteSearch.PlainToTsQuery.monomorphic.get
   override val tsSearch = SoQLRewriteSearch.TsSearch.monomorphic.get
   override val concat = MonomorphicFunction(SoQLFunctions.Concat, Map("a" -> SoQLText, "b" -> SoQLText))
 
@@ -73,8 +73,8 @@ object SoQLRewriteSearch {
   // These result types are lies (they should be SoQLTSVector and
   // SoQLTSQuery respectively), but since users can't name these
   // functions it's ok-ish
-  val ToTsVector = mf("to_tsvector", FunctionName("to_tsvector (unnameable)"), Seq(SoQLText, SoQLText), Nil, SoQLText)
-  val ToTsQuery = mf("to_tsquery", FunctionName("to_tsquery (unnameable)"), Seq(SoQLText, SoQLText), Nil, SoQLText)
+  val ToTsVector = mf("to_tsvector", FunctionName("to_tsvector (unnameable)"), Seq(SoQLText), Nil, SoQLText)
+  val PlainToTsQuery = mf("plainto_tsquery", FunctionName("plainto_tsquery (unnameable)"), Seq(SoQLText), Nil, SoQLText)
 
   val TsSearch = mf("tssearch", FunctionName("search (unnameable)"), Seq(SoQLText, SoQLText), Nil, SoQLBoolean)
 }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/TestRewriteSearch.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/TestRewriteSearch.scala
@@ -38,7 +38,7 @@ object TestRewriteSearch extends RewriteSearch[SqlizerTest.TestMT] {
       Seq(left, right)
     )(FuncallPositionInfo.None)
 
-  override def toTsQuery: MonomorphicFunction = ???
+  override def plainToTsQuery: MonomorphicFunction = ???
   override def toTsVector: MonomorphicFunction = ???
   override def tsSearch: MonomorphicFunction = ???
 


### PR DESCRIPTION
* The query conversion function is actually plainto_tsquery, not to_tsquery
* the first argument to to_tsvector and plainto_tsquery is _not_ a text literal, though it looks like one.