### PR TITLE
More flexible sqlization and a slightly cleaner API

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
@@ -88,7 +88,7 @@ class SoQLFunctionSqlizerTest extends FunSuite with MustMatchers with SqlizerUni
 
     if(useSelectListReferences) analysis = analysis.useSelectListReferences
 
-    sqlizer(analysis.statement, Map.empty).sql.layoutSingleLine.toString
+    sqlizer(analysis.statement).sql.layoutSingleLine.toString
   }
 
   test("basic search") {

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SqlizerTest.scala
@@ -65,7 +65,7 @@ class SqlizerTest extends FunSuite with MustMatchers with SqlizerUniverse[Sqlize
         case Left(err) => fail("Bad query: " + err)
       }
 
-    sqlizer(analysis.statement, Map.empty).sql
+    sqlizer(analysis.statement).sql
   }
 
   test("simple") {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
@@ -111,7 +111,7 @@ object ProcessQuery {
       else physicalTableMap(nameAnalysis)
 
     val sqlizer = new ActualSqlizer(SqlUtils.escapeString(pgu.conn, _), cryptProviders, systemContext, rewriteSubcolumns(request.locationSubcolumns, copyCache), physicalTableFor)
-    val Sqlizer.Result(sql, extractor, nonliteralSystemContextLookupFound, now) = sqlizer(nameAnalysis.statement, OrderedMap.empty)
+    val Sqlizer.Result(sql, extractor, nonliteralSystemContextLookupFound, now) = sqlizer(nameAnalysis.statement)
     log.debug("Generated sql:\n{}", sql) // Doc's toString defaults to pretty-printing
 
     // Our etag will be the hash of the inputs that affect the result of the query


### PR DESCRIPTION
* Make it possible to _not_ apply wrapper functions to top-level output columns (e.g., the "convert to wkb" call that gets done on geometries)
* Remove the availableSchemas parameter from the API.  It's part of the sqlizer's internal state tracking and was always just an empty map.