### PR TITLE
Simplify assembly filenames

### DIFF
--- a/soql-server-pg/build.sbt
+++ b/soql-server-pg/build.sbt
@@ -10,6 +10,10 @@ libraryDependencies ++= Seq(
 
 assembly/test := {}
 
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value
+
 mainClass := Some("com.socrata.pg.server.QueryServer")
 
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)

--- a/store-pg/build.sbt
+++ b/store-pg/build.sbt
@@ -9,3 +9,7 @@ libraryDependencies ++= Seq(
 )
 
 assembly/test := {}
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value


### PR DESCRIPTION
* The filenames no longer contain the version number
* The files are stored in target instead of target/scala-$version