### PR TITLE
On the new query path, do less de/recompression of responses

### DIFF
--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -739,6 +739,14 @@ object QueryServer extends DynamicPortMap {
       val handler = ThreadRenamingHandler(NewLoggingHandler(logOptions)(queryServer.route))
       val server = new SocrataServerJetty(handler,
                      SocrataServerJetty.defaultOptions.
+                       withGzipOptions(
+                         Some(
+                           SocrataServerJetty.Gzip.defaultOptions.
+                             withExcludedMimeTypes(
+                               Set("application/x-socrata-gzipped-cjson")
+                             )
+                         )
+                       ).
                        withPort(config.port).
                        withExtraHandlers(List(SocrataHttpSupport.getHandler(config.metrics))).
                        withPoolOptions(SocrataServerJetty.Pool(config.threadpool)).


### PR DESCRIPTION
Instead of decompressing them and then re-compressing them at query-coordinator and soda-fountain, just compress them once here and then pass that through.  This means no more transparent gzip compression from jetty, so disable that for the (new) content-type that this response has.