### PR TITLE
Only create FTS indexes on rollup if they look like materialized views

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/RollupAnalyzer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/RollupAnalyzer.scala
@@ -72,7 +72,7 @@ object RollupAnalyzer {
     pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
     currentCopy: CopyInfo,
     rollupInfo: LocalRollupInfo
-  ): Option[(SoQLAnalysis[DatabaseNamesMetaTypes], LocationSubcolumnsMap, CryptProviderProvider)] =
+  ): Option[(FoundTables[RollupMetaTypes], SoQLAnalysis[DatabaseNamesMetaTypes], LocationSubcolumnsMap, CryptProviderProvider)] =
   {
     val NewRollupSoqlInfo(foundTablesRaw, locationSubcolumnsRaw, rewritePasses, userParameters) = try {
       JsonUtil.parseJson[NewRollupSoqlInfo](rollupInfo.soql) match {
@@ -210,6 +210,6 @@ object RollupAnalyzer {
       }
     }
 
-    Some((analysis, RewriteSubcolumns(locationSubcolumns, copyCache), cryptProviders))
+    Some((foundTables, analysis, RewriteSubcolumns(locationSubcolumns, copyCache), cryptProviders))
   }
 }

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
@@ -84,7 +84,7 @@ object ProcessQuery {
           filter(_.soql.startsWith("{")).
           filter { rollup => tableExists(pgu, rollup.tableName) }.
           flatMap { rollup => RollupAnalyzer(pgu, copy, rollup).map((rollup, _)) }.
-          map { case (rollup, (analysis, _locationSubcolumnsMap, _cryptProvider)) =>
+          map { case (rollup, (_foundTables, analysis, _locationSubcolumnsMap, _cryptProvider)) =>
             // don't care about the other two things because:
             //   * we're not going to be sqlizing this rollup
             //   * any referenced datasets we already know about


### PR DESCRIPTION
One of the things you can do in this new system is say "create a rollup with the query of this saved view" and while this doesn't imply automatically regenerating this rollup when that saved view changes, the fact that it was initially created from a view is propagated down to the place it's turned into a SQL table.  So, since FTS indexes are easily the slowest kind of index to create, let's only do that if it looks like the "rollup" is actually a "materialized view", since otherwise it's extremely unlikely to ever actually be used.