### PR TITLE
Track rollup IDs through rollup-rewriting and metricize the chosen ones

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/rollup/RollupInfo.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/rollup/RollupInfo.scala
@@ -7,8 +7,10 @@ import com.socrata.soql.collection.OrderedMap
 import com.socrata.soql.environment.ColumnName
 
 import com.socrata.pg.analyzer2.SqlizerUniverse
+import com.socrata.pg.store.RollupId
 
 trait RollupInfo[MT <: MetaTypes] extends SqlizerUniverse[MT] {
+  val id: RollupId
   val statement: Statement
   val resourceName: types.ScopedResourceName[MT]
   val databaseName: DatabaseTableName

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupExactTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupExactTest.scala
@@ -18,7 +18,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text, num * 5, num from @twocol where num = 5 order by text")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text, num * 5, num from @twocol where num = 5 order by text")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -38,7 +38,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text, num * 5, bottom_dword(num) from @twocol where num = 5 order by text")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text, num * 5, bottom_dword(num) from @twocol where num = 5 order by text")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -58,7 +58,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text, num, num+num from @twocol |> select text, num * 5, bottom_dword(num) where num = 5 order by text")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text, num, num+num from @twocol |> select text, num * 5, bottom_dword(num) where num = 5 order by text")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -78,7 +78,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text, num, sum(another_num) from @threecol group by text, num")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text, num, sum(another_num) from @threecol group by text, num")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -98,7 +98,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select bottom_dword(num1), max(num2) from @twocol group by bottom_dword(num1)")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select bottom_dword(num1), max(num2) from @twocol group by bottom_dword(num1)")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -118,7 +118,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select * from @twocol where num > 5")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select * from @twocol where num > 5")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -138,7 +138,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text, sum(num), count(num) from @twocol group by text")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text, sum(num), count(num) from @twocol group by text")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -158,7 +158,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num), count(num) from @twocol group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num), count(num) from @twocol group by text1, text2")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -178,7 +178,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
     TestRollupExact(select, rollup, analysis.labelProvider) must be (None)
   }
 
@@ -192,7 +192,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -212,7 +212,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol where text2 = 'world' group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol where text2 = 'world' group by text1, text2")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -232,7 +232,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol where text1 = 'hello' group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol where text1 = 'hello' group by text1, text2")
     TestRollupExact(select, rollup, analysis.labelProvider) must be (None)
   }
 
@@ -246,7 +246,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
     TestRollupExact(select, rollup, analysis.labelProvider) must be (None)
   }
 
@@ -260,7 +260,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol group by text1, text2")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -280,7 +280,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol where text2 = 'world' group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol where text2 = 'world' group by text1, text2")
     val Some(result) = TestRollupExact(select, rollup, analysis.labelProvider)
 
     locally {
@@ -300,7 +300,7 @@ class RollupExactTest extends FunSuite with MustMatchers with RollupTestHelper w
     val Right(analysis) = analyzer(foundTables, UserParameters.empty)
     val select = analysis.statement.asInstanceOf[Select]
 
-    val rollup = TestRollupInfo("rollup", tf, "select text1, text2, sum(num) from @threecol where text1 = 'hello' group by text1, text2")
+    val rollup = TestRollupInfo(1, "rollup", tf, "select text1, text2, sum(num) from @threecol where text1 = 'hello' group by text1, text2")
     TestRollupExact(select, rollup, analysis.labelProvider) must be (None)
   }
 }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupRewriterTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupRewriterTest.scala
@@ -7,6 +7,7 @@ import com.socrata.soql.analyzer2.mocktablefinder._
 import com.socrata.soql.environment.ResourceName
 
 import com.socrata.pg.analyzer2._
+import com.socrata.pg.store.RollupId
 
 class RollupRewriterTest extends FunSuite with MustMatchers with RollupTestHelper with SqlizerUniverse[TestHelper.TestMT] {
   test("can produce multiple candidates if there are multiple rollups") {
@@ -28,8 +29,8 @@ class RollupRewriterTest extends FunSuite with MustMatchers with RollupTestHelpe
     val expr = new TestRollupRewriter(
       analysis.labelProvider,
       Seq(
-        TestRollupInfo("rollup1", tf, "select @twocol.text as twocol_text, @twocol.num as twocol_num, @english.num as english_num, @english.name as english_name from @twocol join @english on @twocol.num = @english.num"),
-        TestRollupInfo("rollup2", tf, "select text, num, @english.name, count(*) from @twocol join @english on num = @english.num group by text, num, @english.name")
+        TestRollupInfo(1, "rollup1", tf, "select @twocol.text as twocol_text, @twocol.num as twocol_num, @english.num as english_num, @english.name as english_name from @twocol join @english on @twocol.num = @english.num"),
+        TestRollupInfo(2, "rollup2", tf, "select text, num, @english.name, count(*) from @twocol join @english on num = @english.num group by text, num, @english.name")
       )
     )
 
@@ -39,13 +40,51 @@ class RollupRewriterTest extends FunSuite with MustMatchers with RollupTestHelpe
     locally {
       val Right(expectedRollup1FT) = tf.findTables(1, "select c1, c4, count(*) from @rollup1 group by c1, c4", Map.empty)
       val Right(expectedRollup1Analysis) = analyzer(expectedRollup1FT, UserParameters.empty)
-      result(0) must be (isomorphicTo(expectedRollup1Analysis.statement))
+      result(0)._1 must be (isomorphicTo(expectedRollup1Analysis.statement))
+      result(0)._2 must be (Set(RollupId(1)))
     }
 
     locally {
       val Right(expectedRollup2FT) = tf.findTables(1, "select c1, c3, sum(c4) from @rollup2 group by c1, c3", Map.empty)
       val Right(expectedRollup2Analysis) = analyzer(expectedRollup2FT, UserParameters.empty)
-      result(1) must be (isomorphicTo(expectedRollup2Analysis.statement))
+      result(1)._1 must be (isomorphicTo(expectedRollup2Analysis.statement))
+      result(1)._2 must be (Set(RollupId(2)))
     }
+  }
+
+  test("Will report multiple rollup-ids if multiple rollups were used") {
+    val tf = tableFinder(
+      (0, "twocol") -> D("text" -> TestText, "num" -> TestNumber),
+      (0, "english") -> D("num" -> TestNumber, "name" -> TestText),
+
+      // These aren't actually real tables (which is why they're in a
+      // different scope) but we need them to exist so we can
+      // explicitly write soql that refers to them.
+      (1, "rollup1") -> D("c1" -> TestText, "c2" -> TestNumber),
+      (1, "rollup2") -> D("c1" -> TestNumber, "c2" -> TestText)
+    )
+
+    val Right(foundTables) = tf.findTables(0, "(select text, num from @twocol) union (select name, num from @english)", Map.empty)
+    val Right(analysis) = analyzer(foundTables, UserParameters.empty)
+
+    val expr = new TestRollupRewriter(
+      analysis.labelProvider,
+      Seq(
+        TestRollupInfo(1, "rollup1", tf, "select text, num from @twocol"),
+        TestRollupInfo(2, "rollup2", tf, "select num, name from @english")
+      )
+    )
+
+    val result = expr.rollup(analysis.statement)
+    result.length must be (3) // Three because the choices are "use rollup on left, use rollup on right, use rollup on both"
+    val interesting = result.filter(_._2.size == 2)
+    interesting.length must be (1)
+
+    val (stmt, rollupIds) = interesting.head
+    rollupIds must be (Set(RollupId(1), RollupId(2)))
+
+    val Right(expectedRollupFT) = tf.findTables(1, "(select c1, c2 from @rollup1) union (select c2, c1 from @rollup2)", Map.empty)
+    val Right(expectedRollupAnalysis) = analyzer(expectedRollupFT, UserParameters.empty)
+    stmt must be (isomorphicTo(expectedRollupAnalysis.statement))
   }
 }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupTestHelper.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/rollup/RollupTestHelper.scala
@@ -8,6 +8,7 @@ import com.socrata.soql.environment.ResourceName
 import com.socrata.soql.functions.MonomorphicFunction
 
 import com.socrata.pg.analyzer2._
+import com.socrata.pg.store.RollupId
 
 trait RollupTestHelper extends TestHelper { this: Assertions =>
   object TestSemigroupRewriter extends SemigroupRewriter[TestMT] {
@@ -88,6 +89,7 @@ trait RollupTestHelper extends TestHelper { this: Assertions =>
   )
 
   class TestRollupInfo(
+    val id: RollupId,
     val statement: Statement[TestMT],
     val resourceName: types.ScopedResourceName[TestMT],
     val databaseName: types.DatabaseTableName[TestMT]
@@ -96,13 +98,13 @@ trait RollupTestHelper extends TestHelper { this: Assertions =>
   }
 
   object TestRollupInfo {
-    def apply(name: String, tf: TableFinder[TestMT], soql: String): TestRollupInfo = {
+    def apply(id: Int, name: String, tf: TableFinder[TestMT], soql: String): TestRollupInfo = {
       val Right(foundTables) = tf.findTables(0, soql, Map.empty)
       val analysis = analyzer(foundTables, UserParameters.empty) match {
         case Right(a) => a
         case Left(e) => fail(e.toString)
       }
-      new TestRollupInfo(analysis.statement, ScopedResourceName(0, ResourceName(name)), DatabaseTableName(name))
+      new TestRollupInfo(RollupId(id), analysis.statement, ScopedResourceName(0, ResourceName(name)), DatabaseTableName(name))
     }
   }
 


### PR DESCRIPTION
..also actually implement `tableExists`