### PR TITLE
EN-63012: Extracting and refactoring redshift functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,9 @@ val storePG = (project in file("store-pg")).
 val soqlServerPG = (project in file("soql-server-pg")).
   dependsOn(commonPG, storePG % "test->test")
 
+val redshiftBackend = (project in file("redshift-backend")).
+  dependsOn(commonPG, storePG % "test->test")
+
 disablePlugins(AssemblyPlugin)
 
 releaseProcess -= ReleaseTransformations.publishArtifacts

--- a/redshift-backend/build.sbt
+++ b/redshift-backend/build.sbt
@@ -1,0 +1,17 @@
+import Dependencies._
+
+name := "redshift-backend"
+
+libraryDependencies ++= Seq(
+  secondarylib,
+  socrataHttpCuratorBroker,
+  soqlUtils
+)
+
+assembly/test := {}
+
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value
+
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)


### PR DESCRIPTION
Goals:
We need to be able to make use of the following files in external projects (like https://github.com/socrata-platform/soql-redshift-adapter ):
1. common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerRedshift.scala
2. common-pg/src/main/scala/com/socrata/pg/analyzer2/SoqlRepRedshift.scala

We should refactor things so we have a clean common code base for redshift/postgres to branch off from.