### PR TITLE
EN-63009 - Dalia/conditional functions

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
@@ -525,4 +525,15 @@ class SoQLFunctionSqlizerTestRedshift extends FunSuite with Matchers with Sqlize
       """current_date at time zone 'UTC'"""
     )
   }
+
+//  tests for conditional functions
+  test("nullif works") {
+    analyzeStatement("SELECT text, nullif(num, 1)") should equal("""SELECT x1.text AS i1, nullif(x1.num, 1 :: decimal(30, 7)) AS i2 FROM table1 AS x1""")
+  }
+
+  test("coalesce works") {
+    analyzeStatement("SELECT coalesce(text, 'zero'), coalesce(num, '0')") should equal("""SELECT coalesce(x1.text, text 'zero') AS i1, coalesce(x1.num, 0 :: decimal(30, 7)) AS i2 FROM table1 AS x1""")
+  }
+
+
 }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
@@ -535,5 +535,11 @@ class SoQLFunctionSqlizerTestRedshift extends FunSuite with Matchers with Sqlize
     analyzeStatement("SELECT coalesce(text, 'zero'), coalesce(num, '0')") should equal("""SELECT coalesce(x1.text, text 'zero') AS i1, coalesce(x1.num, 0 :: decimal(30, 7)) AS i2 FROM table1 AS x1""")
   }
 
+  test("case works") {
+    analyzeStatement("SELECT num, case(num > 1, 'large num', num <= 1, 'small num')") should equal("""SELECT x1.num AS i1, CASE WHEN (x1.num) > (1 :: decimal(30, 7)) THEN text 'large num' WHEN (x1.num) <= (1 :: decimal(30, 7)) THEN text 'small num' END AS i2 FROM table1 AS x1""")
+  }
 
+  test("iif works") {
+    analyzeStatement("SELECT num, iif(num > 1, 'large num', 'small num')") should equal("""SELECT x1.num AS i1, CASE WHEN (x1.num) > (1 :: decimal(30, 7)) THEN text 'large num' ELSE text 'small num' END AS i2 FROM table1 AS x1""")
+  }
 }


### PR DESCRIPTION
made sure that implementations for the following conditional functions are also valid in redshift:
- case
- iif
- coalesce
- nullif 