### PR TITLE
Add unaccent extension and SOQL function

### DIFF
--- a/common-pg/src/main/resources/com/socrata/pg/store/schema/20231011-create-extension-unaccent.xml
+++ b/common-pg/src/main/resources/com/socrata/pg/store/schema/20231011-create-extension-unaccent.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="setzer" id="20231011-create-extension-unaccent" runOnChange="true">
+        <sql splitStatements="false"><![CDATA[
+          CREATE EXTENSION IF NOT EXISTS unaccent;
+        ]]></sql>
+        <rollback>
+            <sql>
+              DROP EXTENSION IF EXISTS unaccent;
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/soql/SqlFunctions.scala
@@ -82,6 +82,7 @@ object SqlFunctions extends SqlFunctionsLocation with SqlFunctionsGeometry with 
     Trim -> nary("trim") _,
     LeftPad -> formatCall("lpad(%s, %s::int, %s)") _,
     RightPad -> formatCall("rpad(%s, %s::int, %s)") _,
+    Unaccent -> nary("unaccent") _,
 
     GetContext -> contextCall _,
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.14.21"
+    val soqlStdlib = "4.14.22"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "4.2.15"
     val typesafeScalaLogging = "3.9.2"


### PR DESCRIPTION
This maps the SOQL `unaccent` function to its Postgres equivalent (see https://github.com/socrata-platform/soql-reference/pull/349).

Because the function belongs to a trusted extension ([reference](https://www.postgresql.org/docs/current/unaccent.html)), this also includes a migration to create the extension.