### PR TITLE
[EN-63003] - Dalia/geo casts

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerRedshift.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerRedshift.scala
@@ -516,12 +516,14 @@ class SoQLFunctionSqlizerRedshift[MT <: MetaTypes with metatypes.SoQLMetaTypesEx
       GetUtcDate -> expr"current_date at time zone 'UTC'",
 
       // Geo-casts
-      TextToPoint -> sqlizeGeomCast("st_pointfromtext"),
-      TextToMultiPoint -> sqlizeGeomCast("st_mpointfromtext"),
-      TextToLine -> sqlizeGeomCast("st_linefromtext"),
-      TextToMultiLine -> sqlizeGeomCast("st_mlinefromtext"),
-      TextToPolygon -> sqlizeGeomCast("st_polygonfromtext"),
-      TextToMultiPolygon -> sqlizeGeomCast("st_mpolyfromtext"),
+//      st_geomfromtext is the only function in redshift for text to geom conversion - geom subtypes are not verified through that function
+      TextToPoint -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+      TextToMultiPoint -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+      TextToLine -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+      TextToMultiLine -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+      TextToPolygon -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+      TextToMultiPolygon -> sqlizeNormalOrdinaryFuncall("st_geomfromtext", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
+//    TODO implement TextToLocation
       TextToLocation -> sqlizeNormalOrdinaryFuncall("soql_text_to_location", suffixArgs = Seq(Geo.defaultSRIDLiteral)),
 
       // Geo

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
@@ -758,9 +758,31 @@ class SoQLFunctionSqlizerTestRedshift extends FunSuite with Matchers with Sqlize
   }
 
 //  tests for geo-casts
-  test("geo casts are working") {
-    analyzeStatement("SELECT point(0 3) :: point") should equal("blaa")
+  test("geo cast text to point works") {
+    analyzeStatement("SELECT ('POINT' || '(0 9)') :: point") should equal("""SELECT st_asbinary(st_geomfromtext((text 'POINT') || (text '(0 9)'), 4326)) AS i1 FROM table1 AS x1""")
   }
+
+  test("geo cast text to multipoint works") {
+    analyzeStatement("SELECT ('MULTIPOINT' || '((0 0), (1 1))') :: multipoint") should equal("""SELECT st_asbinary(st_geomfromtext((text 'MULTIPOINT') || (text '((0 0), (1 1))'), 4326)) AS i1 FROM table1 AS x1""")
+  }
+
+  test("geo cast text to line works") {
+    analyzeStatement("SELECT ('LINESTRING' || '(0 0, 0 1, 1 2)') :: line") should equal("""SELECT st_asbinary(st_geomfromtext((text 'LINESTRING') || (text '(0 0, 0 1, 1 2)'), 4326)) AS i1 FROM table1 AS x1""")
+  }
+
+  test("geo cast text to multiline works") {
+    analyzeStatement("SELECT ('MULTILINESTRING' || '((0 0, 1 1), (2 2, 3 3))') :: multiline") should equal("""SELECT st_asbinary(st_geomfromtext((text 'MULTILINESTRING') || (text '((0 0, 1 1), (2 2, 3 3))'), 4326)) AS i1 FROM table1 AS x1""")
+  }
+
+  test("geo cast text to polygon works") {
+    analyzeStatement("SELECT ('POLYGON' || '((0 0, 1 0, 1 1, 0 1, 0 0))') :: polygon") should equal("""SELECT st_asbinary(st_geomfromtext((text 'POLYGON') || (text '((0 0, 1 0, 1 1, 0 1, 0 0))'), 4326)) AS i1 FROM table1 AS x1""")
+  }
+
+  test("geo cast text to multipolygon works") {
+    analyzeStatement("SELECT ('MULTIPOLYGON' || '(((1 1, 1 3, 3 3, 3 1, 1 1)), ((4 3, 6 3, 6 1, 4 1, 4 3)))') :: multipolygon") should equal("""SELECT st_asbinary(st_geomfromtext((text 'MULTIPOLYGON') || (text '(((1 1, 1 3, 3 3, 3 1, 1 1)), ((4 3, 6 3, 6 1, 4 1, 4 3)))'), 4326)) AS i1 FROM table1 AS x1""")
+  }
+
+
 }
 
 

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
@@ -759,7 +759,7 @@ class SoQLFunctionSqlizerTestRedshift extends FunSuite with Matchers with Sqlize
 
 //  tests for geo-casts
   test("geo casts are working") {
-    analyzeStatement("SELECT point(0 3) :: point")
+    analyzeStatement("SELECT point(0 3) :: point") should equal("blaa")
   }
 }
 

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTestRedshift.scala
@@ -756,6 +756,11 @@ class SoQLFunctionSqlizerTestRedshift extends FunSuite with Matchers with Sqlize
   test("(window function) stddev_samp works") {
     analyzeStatement("SELECT text, num, stddev_samp(num) over(partition by text order by num rows between unbounded preceding and unbounded following)") should equal("""SELECT x1.text AS i1, x1.num AS i2, stddev_samp(x1.num) OVER (PARTITION BY x1.text ORDER BY x1.num ASC NULLS LAST ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS i3 FROM table1 AS x1""")
   }
+
+//  tests for geo-casts
+  test("geo casts are working") {
+    analyzeStatement("SELECT point(0 3) :: point")
+  }
 }
 
 


### PR DESCRIPTION
all geo cast functions are implemented through st_geomfromtext since redshift doesn’t have more specific functions for the different geom subtypes. there is no guarantee that the subtype casted is the actual subtype of the geom data.

implementing the function TextToLocation is blocked by the ticket https://socrata.atlassian.net/browse/EN-62999.


