### PR TITLE
Type-annotate NULL literals in old-analyzer SQL generation

### DIFF
--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerBasicTest.scala
@@ -498,7 +498,7 @@ class SqlizerBasicTest extends SqlizerTest {
     val ts2 = new Timestamp(dt2.getMillis)
     val ts3 = new Timestamp(dt3.getMillis)
     params should be (Seq(ts1, ts2, ts3))
-    sql should be ("SELECT (1::numeric) WHERE (((null = (?::timestamp)) or (null = (?::timestamp with time zone))) or (null = (?::timestamp with time zone)))")
+    sql should be ("SELECT (1::numeric) WHERE ((((null :: TIMESTAMP (3) WITHOUT TIME ZONE) = (?::timestamp)) or ((null :: TIMESTAMP (3) WITH TIME ZONE) = (?::timestamp with time zone))) or ((null :: TIMESTAMP (3) WITH TIME ZONE) = (?::timestamp with time zone)))")
   }
 
   test("timestamp literals use timestamp parameters in date_diff_d") {


### PR DESCRIPTION
This also attempts to fix a related bug whereby compound columns would produce single-column null literals, but for some reason it does not? This definitely produces a multi-column ParametricSql when appropriate, but sqlization of `select null::url` still produces `SELECT (null :: TEXT)` and then tries to read two columns out of the result.  I'm not sure why!