### PR TITLE
NO-JIRA: use columns' (initial) field names in the naming of database…

### DIFF
--- a/store-pg/src/main/scala/com/socrata/pg/store/events/ColumnCreatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/ColumnCreatedHandler.scala
@@ -21,7 +21,13 @@ case class ColumnCreatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQLValue],
     secColInfo.id, // user column id
     secColInfo.fieldName,
     secColInfo.typ,
-    physicalColumnBaseBase(secColInfo.id.underlying, isSystemColumnId(secColInfo.id)), // system column id
+    physicalColumnBaseBase(
+      // in practice, this will always choose to use the field name,
+      // but that _is_ still technically optional so fall back to the
+      // user column id for the name hint if it's not present somehow.
+      secColInfo.fieldName.map(_.name).getOrElse(secColInfo.id.underlying),
+      isSystemColumnId(secColInfo.id)
+    ), // system column id
     None // not going to store computation strategies
   )
 


### PR DESCRIPTION
… cols

This is more or less exactly what truth does when it names its user table columns.