### PR TITLE
Fix DatabaseNamesMetaTypes' FromProvenance instance

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/DatabaseNamesMetaTypes.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/DatabaseNamesMetaTypes.scala
@@ -35,7 +35,7 @@ object DatabaseNamesMetaTypes extends MetaTypeHelper[DatabaseNamesMetaTypes] {
       if(rawProv.startsWith(rollupTag)) {
         DatabaseTableName(AugmentedTableName(rawProv.substring(rollupTag.length), true))
       } else {
-        DatabaseTableName(AugmentedTableName(rawProv.substring(rollupTag.length), false))
+        DatabaseTableName(AugmentedTableName(rawProv, false))
       }
     }
 


### PR DESCRIPTION
This isn't actually (currently) used.