### PR TITLE
Return the data-versions of all referenced datasets in the cjson header

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/CopyCache.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/CopyCache.scala
@@ -13,6 +13,7 @@ import com.socrata.pg.query.QueryServerHelper
 
 trait CopyCache[MT <: MetaTypes] extends LabelUniverse[MT] {
   def apply(dtn: DatabaseTableName): Option[(CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])]
+  def asMap: Map[DatabaseTableName, (CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])]
 
   def allCopies: Seq[CopyInfo]
 }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/InputMetaTypes.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/InputMetaTypes.scala
@@ -76,6 +76,7 @@ object InputMetaTypes {
     private val map = new scm.HashMap[DatabaseTableName, (CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])]
 
     override def allCopies = map.valuesIterator.map(_._1).toVector
+    override def asMap = map.toMap
 
     // returns None if the database table name is unknown to this secondary
     def apply(dtn: DatabaseTableName): Option[(CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])] =

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/RollupMetaTypes.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/metatypes/RollupMetaTypes.scala
@@ -75,6 +75,7 @@ object RollupMetaTypes {
     private val map = new scm.HashMap[DatabaseTableName, (CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])]
 
     override def allCopies = map.valuesIterator.map(_._1).toVector
+    override def asMap = map.toMap
 
     // returns None if the database table name is unknown to this secondary
     def apply(dtn: DatabaseTableName): Option[(CopyInfo, OrderedMap[UserColumnId, ColumnInfo[CT]])] =

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/ordering/package.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/ordering/package.scala
@@ -1,0 +1,19 @@
+package com.socrata.pg.analyzer2
+
+import com.socrata.datacoordinator.id.{DatasetInternalName, UserColumnId}
+
+package object ordering {
+  implicit object datasetInternalNameOrdering extends Ordering[DatasetInternalName] {
+    def compare(a: DatasetInternalName, b: DatasetInternalName) =
+      a.instance.compare(b.instance) match {
+        case 0 => a.datasetId.underlying.compare(b.datasetId.underlying)
+        case n => n
+      }
+  }
+
+  implicit object userColumnIdOrdering extends Ordering[UserColumnId] {
+    def compare(a: UserColumnId, b: UserColumnId) = {
+      a.underlying.compare(b.underlying)
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val socrataCuratorUtils = "1.2.0"
     val socrataThirdPartyUtils = "5.0.0"
     val socrataHttpCuratorBroker = "3.13.4"
-    val soqlStdlib = "4.14.40"
+    val soqlStdlib = "4.14.41"
     val typesafeConfig = "1.0.0"
     val dataCoordinator = "4.2.20"
     val typesafeScalaLogging = "3.9.2"

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ETagify.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ETagify.scala
@@ -17,36 +17,12 @@ import com.socrata.soql.environment.ColumnName
 import com.socrata.soql.sql.Debug
 
 import com.socrata.pg.analyzer2.metatypes.InputMetaTypes
+import com.socrata.pg.analyzer2.ordering._
 
 final abstract class ETagify
 
 object ETagify extends StatementUniverse[InputMetaTypes] {
   private val log = LoggerFactory.getLogger(classOf[ETagify])
-
-  private implicit object datasetInternalNameOrdering extends Ordering[DatasetInternalName] {
-    def compare(a: DatasetInternalName, b: DatasetInternalName) =
-      a.instance.compare(b.instance) match {
-        case 0 => a.datasetId.underlying.compare(b.datasetId.underlying)
-        case n => n
-      }
-  }
-  private implicit object userColumnIdOrdering extends Ordering[UserColumnId] {
-    def compare(a: UserColumnId, b: UserColumnId) = {
-      a.underlying.compare(b.underlying)
-    }
-  }
-  private implicit object dtnOrdering extends Ordering[DatabaseTableName] {
-    private val ord = Ordering[InputMetaTypes#DatabaseTableNameImpl]
-    def compare(a: DatabaseTableName, b: DatabaseTableName) = {
-      ord.compare(a.name, b.name)
-    }
-  }
-  private implicit object dcnOrdering extends Ordering[DatabaseColumnName] {
-    private val ord = Ordering[InputMetaTypes#DatabaseColumnNameImpl]
-    def compare(a: DatabaseColumnName, b: DatabaseColumnName) = {
-      ord.compare(a.name, b.name)
-    }
-  }
 
   def apply(
     outputColumns: Seq[ColumnName],


### PR DESCRIPTION
Idly thinking about how to provide the functionality provided by the x-soda2-data-out-of-date header without unconditionally involving truth on the read path, and plumbing this information out would definitely be part of any such thing.