### PR TITLE
Update the old-analyzer query path to use the new cjson reps too

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/SoQLCommon.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SoQLCommon.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.{ExecutorService, Executors, TimeUnit}
 import com.socrata.datacoordinator.common.soql.{SoQLRep, SoQLRowLogCodec, SoQLTypeContext}
 import com.socrata.datacoordinator.id.{DatasetId, RowId, RowVersion, UserColumnId}
 import com.socrata.datacoordinator.truth.SimpleRowLogCodec
-import com.socrata.datacoordinator.truth.json.JsonColumnRep
 import com.socrata.datacoordinator.truth.loader.RowPreparer
 import com.socrata.datacoordinator.truth.metadata.{AbstractColumnInfoLike, ColumnInfo, DatasetCopyContext, DatasetInfo}
 import com.socrata.datacoordinator.truth.sql.DatasetMapLimits
@@ -98,9 +97,9 @@ class PostgresUniverseCommon(val tablespace: String => Option[String],
   def versionObfuscationContextFor(cryptProvider: CryptProvider): SoQLVersion.StringRep =
     new SoQLVersion.StringRep(cryptProvider)
 
-  def jsonReps(datasetInfo: DatasetInfo, obfuscateId: Boolean): SoQLType => JsonColumnRep[SoQLType,SoQLValue] = {
+  def jsonReps(datasetInfo: DatasetInfo, obfuscateId: Boolean): SoQLType => ErasedCJsonWriteRep[SoQLValue] = {
     val cp = new CryptProvider(datasetInfo.obfuscationKey)
-    SoQLRep.jsonRep(idObfuscationContextFor(cp, obfuscateId), versionObfuscationContextFor(cp))
+    SoQLRep.jsonRep(cp, obfuscateId)
   }
 
   def rowPreparer(transactionStart: DateTime, // scalastyle:ignore method.length

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.14.42"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "4.2.20"
+    val dataCoordinator = "4.2.21"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -22,7 +22,6 @@ import com.socrata.datacoordinator.common.{DataSourceConfig, DataSourceFromConfi
 import com.socrata.datacoordinator.id._
 import com.socrata.datacoordinator.truth.loader.sql.PostgresRepBasedDataSqlizer
 import com.socrata.datacoordinator.truth.metadata._
-import com.socrata.datacoordinator.truth.json.JsonColumnWriteRep
 import com.socrata.datacoordinator.util.CloseableIterator
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.http.common.AuxiliaryData


### PR DESCRIPTION
Because they're gone from the DC library (but the DC's rep-selector function is still there so that continues to be used)