### PR TITLE
Cache known-to-be-small responses in memory

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,7 @@ object Dependencies {
     val c3p0 = "0.9.5-pre9"
     val commonsCli = "1.2"
     val commonsCodec = "1.5"
+    val commonsCollections = "4.4"
     val commonsIo = "1.4"
     val commonsLang = "2.6"
     val jodaConvert = "1.2"
@@ -35,6 +36,8 @@ object Dependencies {
   val commonsCli = "commons-cli" % "commons-cli" % versions.commonsCli
 
   val commonsCodec = "commons-codec" % "commons-codec" % versions.commonsCodec
+
+  val commonsCollections = "org.apache.commons" % "commons-collections4" % versions.commonsCollections
 
   val commonsIo = "commons-io" % "commons-io" % versions.commonsIo
 

--- a/soql-server-pg/build.sbt
+++ b/soql-server-pg/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 name := "soql-server-pg"
 
 libraryDependencies ++= Seq(
+  commonsCollections,
   secondarylib,
   socrataHttpCuratorBroker,
   soqlUtils

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ResultCache.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ResultCache.scala
@@ -1,0 +1,53 @@
+package com.socrata.pg.server.analyzer2
+
+import scala.util.hashing.MurmurHash3
+
+import org.apache.commons.collections4.map.LRUMap
+import org.joda.time.DateTime
+
+import com.socrata.http.server.util.{EntityTag, WeakEntityTag, StrongEntityTag}
+import com.socrata.soql.analyzer2._
+
+object ResultCache {
+  case class Result(etag: EntityTag, lastModified: DateTime, contentType: String, body: Array[Byte])
+
+  private class WrappedETag(private val underlying: EntityTag) {
+    override val hashCode =
+      MurmurHash3.bytesHash(underlying.asBytesUnsafe)
+
+    override def equals(o: Any) =
+      o match {
+        case that: WrappedETag =>
+          (this.underlying, that.underlying) match {
+            case (a: WeakEntityTag, b: WeakEntityTag) => a.weakCompare(b)
+            case (a: StrongEntityTag, b: StrongEntityTag) => a.strongCompare(b)
+            case _ => false
+          }
+        case _ =>
+          false
+      }
+  }
+
+  private val cache = new LRUMap[WrappedETag, Result](10000)
+
+  def apply(etag: EntityTag): Option[Result] = {
+    val k = new WrappedETag(etag)
+    Option(cache.synchronized { cache.get(k) })
+  }
+
+  def save(etag: EntityTag, lastModified: DateTime, contentType: String, body: Array[Byte]): Unit = {
+    val k = new WrappedETag(etag)
+    val r = Result(etag, lastModified, contentType, body)
+    cache.synchronized { cache.put(k, r) }
+  }
+
+  def isCacheable(analysis: SoQLAnalysis[_]): Boolean = {
+    // a response is cacheable if it's known to be small - currently,
+    // "known to be small" means "it's an aggregate query with no
+    // GROUP BY clause (i.e., the entire query is one group)".
+    analysis.statement match {
+      case sel: Select[_] if sel.isAggregated && sel.groupBy.isEmpty => true
+      case _ => false
+    }
+  }
+}


### PR DESCRIPTION
In particular, "count(*)" is a common request to make which can be very expensive to compute but which will result in A Number.  Let's avoid computing that over and over as much as possible!