### PR TITLE
EN-66368: v3 rollups use either internal names or resource names

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/store/SecondaryManagerBase.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/SecondaryManagerBase.scala
@@ -1,6 +1,6 @@
 package com.socrata.pg.store
 
-import com.socrata.datacoordinator.id.UserColumnId
+import com.socrata.datacoordinator.id.{UserColumnId, DatasetResourceName}
 import com.socrata.datacoordinator.truth.metadata.{ColumnInfo, CopyInfo}
 import com.socrata.datacoordinator.truth.sql.SqlColumnRep
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
@@ -42,7 +42,7 @@ abstract class SecondaryManagerBase(pgu: PGSecondaryUniverse[SoQLType, SoQLValue
     }.toMap
   }
 
-  protected def getDsSchema(resourceName: ResourceName): ColumnIdMap[ColumnInfo[SoQLType]] = {
+  protected def getDsSchema(resourceName: DatasetResourceName): ColumnIdMap[ColumnInfo[SoQLType]] = {
     val dsInfo = pgu.datasetMapReader.datasetInfoByResourceName(resourceName).get
     val copyInfo = pgu.datasetMapReader.latest(dsInfo)
     getDsSchema(copyInfo)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.14.51"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "4.2.23"
+    val dataCoordinator = "4.2.24"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"

--- a/store-pg/src/main/scala/com/socrata/pg/store/events/RollupCreatedOrUpdatedHandler.scala
+++ b/store-pg/src/main/scala/com/socrata/pg/store/events/RollupCreatedOrUpdatedHandler.scala
@@ -3,6 +3,7 @@ package com.socrata.pg.store.events
 import com.socrata.datacoordinator.id.RollupName
 import com.socrata.datacoordinator.secondary.{RollupInfo => SecRollupInfo}
 import com.socrata.datacoordinator.truth.metadata.CopyInfo
+import com.socrata.pg.analyzer2.metatypes.RollupMetaTypes
 import com.socrata.pg.store.RollupManager.parseAndCollectTableNames
 import com.socrata.pg.store.{LocalRollupInfo, PGSecondary, PGSecondaryUniverse, RollupManager}
 import com.socrata.soql.environment.ResourceName
@@ -26,9 +27,9 @@ case class RollupCreatedOrUpdatedHandler(pgu: PGSecondaryUniverse[SoQLType, SoQL
   def updateRollupRelationships(rollupInfo: LocalRollupInfo): Unit ={
     for(tableNameOrInternalName <- parseAndCollectTableNames(rollupInfo)) {
       val dsInfo = tableNameOrInternalName match {
-        case Left(tableName) =>
-          pgu.datasetMapReader.datasetInfoByResourceName(new ResourceName(tableName))
-        case Right(dsInternalName) =>
+        case RollupMetaTypes.TableName.ResourceName(tableName) =>
+          pgu.datasetMapReader.datasetInfoByResourceName(tableName)
+        case RollupMetaTypes.TableName.InternalName(dsInternalName) =>
           pgu.datasetMapReader.datasetInfoByInternalName(dsInternalName)
       }
       dsInfo match {

--- a/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
+++ b/store-pg/src/test/scala/com/socrata/pg/store/RollupTest.scala
@@ -319,7 +319,7 @@ class RollupTest extends PGSecondaryTestBase with PGSecondaryUniverseTestBase wi
       // test getCopyAndRollupMaps
       val regularTableName = TableName(datasetInfo.resourceName.underlying)
       val rollupTableName = TableName(s"${datasetInfo.resourceName.underlying}.${rollupInfo.name.underlying}")
-      val (copyMap, rollupMap) = QueryServerHelper.getCopyAndRollupMaps(pgu,Seq(regularTableName, rollupTableName, PrimaryTable), ResourceName(datasetInfo.resourceName.underlying), None)
+      val (copyMap, rollupMap) = QueryServerHelper.getCopyAndRollupMaps(pgu,Seq(regularTableName, rollupTableName, PrimaryTable), datasetInfo.resourceName, None)
       copyMap(regularTableName) should be (copyInfo)
       rollupMap(rollupTableName) should be (rollupInfo)
       copyMap.size should be (1)


### PR DESCRIPTION
Just temporarily until we update exsting new-analyzer rollups, then all rollups will use resource names and the TableName class can be removed.