### PR TITLE
Improve cachability on domains with user context turned on

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExtraContext.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExtraContext.scala
@@ -8,24 +8,61 @@ import com.socrata.soql.sqlizer.ExtraContext
 import com.socrata.pg.analyzer2.metatypes.DatabaseNamesMetaTypes
 
 class SoQLExtraContext(
-  val systemContext: Map[String, String],
+  systemContext: Map[String, String],
   val cryptProviderProvider: CryptProviderProvider,
   val locationSubcolumns: SoQLExtraContext.LocationSubcolumns,
   val escapeString: String => String
 ) extends ExtraContext[SoQLExtraContext.Result] {
-  val now = DateTime.now()
-  var nonliteralSystemContextLookupFound: Boolean = false
-  var nowUsed = false
+  private val actualNow = DateTime.now()
+  private var nowUsed = false
+
+  def now: DateTime = {
+    nowUsed = true
+    actualNow
+  }
+
+  private var systemContextUsed: SoQLExtraContext.SystemContextUsed =
+    SoQLExtraContext.SystemContextUsed.Static(systemContext, Set())
+
+  def systemContextKeyUsed(key: String): Option[String] = {
+    systemContextUsed += key
+    systemContextUsed.allContext.get(key)
+  }
+
+  def nonLiteralSystemContextUsed(): Unit =
+    systemContextUsed = systemContextUsed.dynamic
 
   override def finish() =
     SoQLExtraContext.Result(
-      nonliteralSystemContextLookupFound,
-      if(nowUsed) Some(now) else None
+      systemContextUsed,
+      if(nowUsed) Some(actualNow) else None
     )
 }
 
 object SoQLExtraContext extends StatementUniverse[DatabaseNamesMetaTypes] {
   type LocationSubcolumns = Map[DatabaseTableName, Map[DatabaseColumnName, Seq[Option[DatabaseColumnName]]]]
 
-  case class Result(nonliteralSystemContextLookupFound: Boolean, now: Option[DateTime])
+  sealed abstract class SystemContextUsed {
+    def +(key: String): SystemContextUsed
+    def allContext: Map[String, String]
+    def relevantEtagContext: Map[String, String]
+    def dynamicContext: Map[String, String]
+    def dynamic: SystemContextUsed.Dynamic
+  }
+  object SystemContextUsed {
+    case class Dynamic(allContext: Map[String, String]) extends SystemContextUsed {
+      override def +(key: String) = this
+      override def relevantEtagContext = allContext
+      override def dynamicContext = allContext
+      override def dynamic = this
+    }
+    case class Static(allContext: Map[String, String], keys: Set[String]) extends SystemContextUsed {
+      override def +(key: String) = Static(allContext, keys + key)
+      override def relevantEtagContext = allContext.filterKeys(keys)
+      override def dynamicContext = Map.empty
+      override def dynamic = Dynamic(allContext)
+    }
+  }
+
+  case class Result(systemContextUsed: SystemContextUsed, now: Option[DateTime])
 }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
@@ -141,7 +141,7 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with (
 
     f.args(0) match {
       case lit@LiteralValue(SoQLText(key)) =>
-        ctx.extraContext.systemContext.get(key) match {
+        ctx.extraContext.systemContextKeyUsed(key) match {
           case Some(value) =>
             ctx.repFor(SoQLText).literal(LiteralValue[MT](SoQLText(value))(f.position.asAtomic))
               .withExpr(f)
@@ -151,7 +151,7 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with (
       case e@NullLiteral(typ) =>
         nullLiteral
       case _ =>
-        ctx.extraContext.nonliteralSystemContextLookupFound = true
+        ctx.extraContext.nonLiteralSystemContextUsed()
         val hashedArg = Seq(args(0).compressed.sql).funcall(d"md5").group
         val prefixedArg = d"'socrata_system.a' ||" +#+ hashedArg
         val lookup = Seq(prefixedArg.group, d"true").funcall(d"current_setting")
@@ -219,7 +219,6 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with (
     assert(f.typ == SoQLFixedTimestamp)
     assert(args.length == 0)
 
-    ctx.extraContext.nowUsed = true
     ctx.repFor(f.typ).
       literal(LiteralValue[MT](SoQLFixedTimestamp(ctx.extraContext.now))(AtomicPositionInfo.Synthetic)).
       withExpr(f)


### PR DESCRIPTION
* Only use for etag generation those parts of the context which are actually used.  If a non-literal is used, then and only then assume "all of it" when generating the fingerprint.
* make it so that the very fact of getting `now` out of the extra-context records the fact that `now` was used

The first one means that queries which do not actually use the system context will not return different fingerprints for different users.