### PR TITLE
Don't grab all copies when we don't need all copies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     val socrataHttpCuratorBroker = "3.13.4"
     val soqlStdlib = "4.14.56"
     val typesafeConfig = "1.0.0"
-    val dataCoordinator = "4.2.26"
+    val dataCoordinator = "4.2.28"
     val typesafeScalaLogging = "3.9.2"
     val rojomaJson = "3.13.0"
     val metrics = "4.1.2"


### PR DESCRIPTION
Significant perf win on datasets with lots of copies