### PR TITLE
Don't use pg config for dynamic system context lookups

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
@@ -158,9 +158,7 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with (
         nullLiteral
       case _ =>
         ctx.extraContext.nonLiteralSystemContextUsed()
-        val hashedArg = Seq(args(0).compressed.sql).funcall(d"md5").group
-        val prefixedArg = d"'socrata_system.a' ||" +#+ hashedArg
-        val lookup = Seq(prefixedArg.group, d"true").funcall(d"current_setting")
+        val lookup = Seq(args(0).compressed.sql).funcall(d"pg_temp.dynamic_system_context")
         exprSqlFactory(lookup, f)
     }
   }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
@@ -216,7 +216,7 @@ class SoQLFunctionSqlizerTest extends FunSuite with MustMatchers with SqlizerUni
   }
 
   test("get_context non-literal") {
-    analyze("get_context(text)") must equal ("""current_setting('socrata_system.a' || md5(x1.text), true)""")
+    analyze("get_context(text)") must equal ("""pg_temp.dynamic_system_context(x1.text)""")
   }
 
   test("url(x, y).url == x") {

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/DynamicSystemContextHelper.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/DynamicSystemContextHelper.scala
@@ -1,0 +1,43 @@
+package com.socrata.pg.server.analyzer2
+
+import java.sql.Connection
+
+import com.rojoma.simplearm.v2._
+
+import com.socrata.soql.analyzer2.MetaTypes
+import com.socrata.soql.environment.Provenance
+import com.socrata.soql.sqlizer.{MetaTypesExt, Rep}
+
+import com.socrata.pg.store.SqlUtils
+
+object DynamicSystemContextHelper {
+  def generateDynamicSystemContext(conn: Connection, ctx: Map[String, String]): String = {
+    def mkStringLiteral(s: String): String = "'" + SqlUtils.escapeString(conn, s) + "'"
+    def mkTextLiteral(s: String): String = "text " + mkStringLiteral(s)
+
+    val body =
+      if(ctx.isEmpty) {
+        // We can have an empty dynamic context; this happens if a
+        // user calls get_context with a non-literal parameter on a
+        // dataset where core provides no context.  In that case, the
+        // only answer can be NULL.
+        "  SELECT null :: text"
+      } else {
+        ctx.iterator.map { case (key, value) =>
+          s"""    WHEN ${mkTextLiteral(key)} THEN ${mkTextLiteral(value)}"""
+        }.mkString("  SELECT CASE key\n", "\n", "\n  END")
+      }
+
+    val header = """CREATE OR REPLACE FUNCTION pg_temp.dynamic_system_context(key text) RETURNS text AS $$"""
+    val footer = """$$ LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE"""
+
+    s"$header\n$body\n$footer"
+  }
+
+  def setupDynamicSystemContext(conn: Connection, ctx: Map[String, String]): Unit = {
+    val sql = generateDynamicSystemContext(conn, ctx);
+    using(conn.createStatement()) { stmt =>
+      stmt.execute(sql)
+    }
+  }
+}


### PR DESCRIPTION
This was always a hack; PG's settings system was absolutely not meant for this and it's always bothered me that we were using it even beyond the bug that if you happened to use an unset config val in a session where it had been previously set, you'd get back an empty string insetad of null.

Now instead if dynamic config vals are used in a query, we create a function in pg_temp (which is specifically for storing per-transaction stuff) and call it there.