### PR TITLE
Add an ENCODING parameter to the COPY command used for querying

### DIFF
--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
@@ -591,7 +591,7 @@ object ProcessQuery {
     }
 
     val it = new Iterator[Array[JValue]] {
-      private val stream = rs.open(new PGCopyInputStream(conn.unwrap(classOf[PGConnection]), s"COPY ($sql) TO STDOUT WITH (FORMAT csv, HEADER false)"))
+      private val stream = rs.open(new PGCopyInputStream(conn.unwrap(classOf[PGConnection]), s"COPY ($sql) TO STDOUT WITH (FORMAT csv, HEADER false, ENCODING 'utf-8')"))
       private val reader = rs.open(new InputStreamReader(stream, StandardCharsets.UTF_8), transitiveClose = List(stream))
       private val csv = rs.open(CSVParserBuilder.Postgresql.build(reader).iterator, transitiveClose = List(reader))
 


### PR DESCRIPTION
Shouldn't actually do anything right now, but it keeps us robust in the face of configuration changes - now both sides of this read explicitly expect to be using UTF-8, instead of one side being implicit.