### PR TITLE
EN-69912: Prevent the old-analyzer from generating bad aliases

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/query/QueryServerHelper.scala
@@ -39,12 +39,13 @@ object QueryServerHelper {
     val copy = getCopy(pgu, datasetInfo, reqCopy)
     val cryptProvider = datasetInfo.cryptProvider
 
-    val sqlCtx = Map[SqlizerContext, Any](
+    def sqlCtx = Map[SqlizerContext, Any](
       SqlizerContext.IdRep -> (if (obfuscateId) { new SoQLID.StringRep(cryptProvider) }
                                else { new ClearNumberRep(cryptProvider) }),
       SqlizerContext.VerRep -> new SoQLVersion.StringRep(cryptProvider),
       SqlizerContext.CaseSensitivity -> caseSensitivity,
-      SqlizerContext.LeadingSearch -> leadingSearch
+      SqlizerContext.LeadingSearch -> leadingSearch,
+      SqlizerContext.NameCache -> new Sqlizer.NameCache
     )
     val escape = (stringLit: String) => SqlUtils.escapeString(pgu.conn, stringLit)
 

--- a/common-pg/src/main/scala/com/socrata/pg/store/IndexManager.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/IndexManager.scala
@@ -73,12 +73,15 @@ class IndexManager(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: Copy
       val querier = readerWithQuery(pgu.conn, pgu, readCtx.copyCtx, baseSchema, None)
       val sqlReps = querier.getSqlReps(readCtx.copyInfo.dataTableName, systemToUserColumnMap)
       val typeReps = toTypeRepMap(baseSchema.values)
+
+      val sqlCtx = sqlizeContext + (NameCache -> new Sqlizer.NameCache)
+
       val psqls = coreExprs.map { expr =>
-        Sqlizer.sql(expr)(sqlReps, typeReps, Seq.empty, sqlizeContext, escape)
+        Sqlizer.sql(expr)(sqlReps, typeReps, Seq.empty, sqlCtx, escape)
       }
 
       val psqlsWhere = analysisCid.where.map { expr =>
-        Sqlizer.sql(expr)(sqlReps, typeReps, Seq.empty, sqlizeContext, escape)
+        Sqlizer.sql(expr)(sqlReps, typeReps, Seq.empty, sqlCtx, escape)
       }
 
       val setParams = psqls.flatMap(_.setParams) ++ psqlsWhere.toSeq.flatMap(_.setParams)

--- a/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/soql/SqlizerTest.scala
@@ -23,9 +23,10 @@ object SqlizerTest {
 
   implicit val materialized: Boolean = false
 
-  val sqlCtx = Map[SqlizerContext, Any](
+  def sqlCtx = Map[SqlizerContext, Any](
     SqlizerContext.IdRep -> new SoQLID.StringRep(cryptProvider),
-    SqlizerContext.VerRep -> new SoQLVersion.StringRep(cryptProvider)
+    SqlizerContext.VerRep -> new SoQLVersion.StringRep(cryptProvider),
+    SqlizerContext.NameCache -> new Sqlizer.NameCache
   )
 
   val typeTable = TableName("_type", None)

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/QueryServer.scala
@@ -475,6 +475,7 @@ class QueryServer(val dsInfo: DSInfo, val caseSensitivity: CaseSensitivity, val 
       }
 
       val sqlCtx = Map[SqlizerContext, Any](
+        SqlizerContext.NameCache -> new Sqlizer.NameCache,
         SqlizerContext.IdRep -> (if (obfuscateId) { new SoQLID.StringRep(cryptProvider) }
                                  else { new ClearNumberRep(cryptProvider) }),
         SqlizerContext.VerRep -> new SoQLVersion.StringRep(cryptProvider),


### PR DESCRIPTION
PG column names can be of any length, but only the first 63 characters are significant.  This is a problem if two SoQL aliases exist which are longer than that.  So, we'll remap such columns at sql-generation time to i#### (where #### is just an incrementing counter as they're encountered).

This is tricker than it sounds, because it's entirely possible for a user-specified column to be called "i####" and we don't want to collide. So for those columns, we'll remap even if the name is below the pg length limits.

Why aren't we just remapping everything?  Because we have no visibility into which columns are physical database columns (and so must not be renamed) and which columns are intermediate (and so can be).  Also there's a massive pile of tests that assume column names don't ordinarily get messed with.