### PR TITLE
When doing an EXPLAIN ANALYZE on the old-analyer path, request buffer…

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/query/DataSqlizerQuerier.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/query/DataSqlizerQuerier.scala
@@ -262,7 +262,7 @@ trait DataSqlizerQuerier[CT, CV] extends AbstractRepBasedDataSqlizer[CT, CV] {
         execute(conn, setTimeout(ms))
       }
 
-      val query = "EXPLAIN " + (if(analyze) "ANALYZE " else "") + pSql.sql.head
+      val query = s"EXPLAIN (ANALYZE $analyze, BUFFERS $analyze, FORMAT text) ${pSql.sql.head}"
 
       // Statement to be closed by caller
       val stmt = conn.prepareStatement(query)


### PR DESCRIPTION
…s info

Also use the new-style extensible syntax.