### PR TITLE
Make new-analyzer agree with old-analyzer wrt get_utc_date precision

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExtraContext.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExtraContext.scala
@@ -1,6 +1,6 @@
 package com.socrata.pg.analyzer2
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
 
 import com.socrata.soql.analyzer2._
 import com.socrata.soql.sqlizer.ExtraContext
@@ -15,7 +15,7 @@ class SoQLExtraContext(
 ) extends ExtraContext[SoQLExtraContext.Result] {
   var obfuscatorRequired = false
 
-  private val actualNow = DateTime.now()
+  private val actualNow = DateTime.now().withZone(DateTimeZone.UTC).withMillisOfSecond(0)
   private var nowUsed = false
 
   def now: DateTime = {


### PR DESCRIPTION
In the OA path it truncates to seconds, so do the same.

Also add `withZone(DateTimeZone.UTC)` to make sure everything agrees about the zone computations should be done in by default.