### PR TITLE
Make it possible to cache coarsended expressions of get_utc_date

### DIFF
--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExprSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExprSqlizer.scala
@@ -23,6 +23,10 @@ class SoQLExprSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with ({ ty
     val FloatingTimestampTruncYm = SoQLFunctions.FloatingTimeStampTruncYm.monomorphic.get
     val FloatingTimestampTruncY = SoQLFunctions.FloatingTimeStampTruncY.monomorphic.get
 
+    val FloatingTimestampExtractDoW = SoQLFunctions.FloatingTimeStampExtractDow.monomorphic.get
+    val FloatingTimestampExtractWoY = SoQLFunctions.FloatingTimeStampExtractWoy.monomorphic.get
+    val FloatingTimestampExtractIsoY = SoQLFunctions.FloatingTimestampExtractIsoY.monomorphic.get
+
     val FixedTimestampZTruncYmd = SoQLFunctions.FixedTimeStampZTruncYmd.monomorphic.get
     val FixedTimestampZTruncYm = SoQLFunctions.FixedTimeStampZTruncYm.monomorphic.get
     val FixedTimestampZTruncY = SoQLFunctions.FixedTimeStampZTruncY.monomorphic.get
@@ -36,6 +40,9 @@ class SoQLExprSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with ({ ty
     val FloatingTimestampDayField = SoQLFunctions.FloatingTimestampDayField.monomorphic.get
 
     val FloatingTimestampDateField = SoQLFunctions.FloatingTimestampDateField.monomorphic.get
+    val FloatingTimestampDayOfWeekField = SoQLFunctions.FloatingTimestampDayOfWeekField.monomorphic.get
+    val FloatingTimestampWeekOfYearField = SoQLFunctions.FloatingTimestampWeekOfYearField.monomorphic.get
+    val FloatingTimestampIsoYearField = SoQLFunctions.FloatingTimestampIsoYearField.monomorphic.get
   }
 
   private sealed abstract class NowInZone {
@@ -75,6 +82,18 @@ class SoQLExprSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with ({ ty
     case class OnlyYear(zoneName: String) extends NowInZone {
       override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
         tsp.nowExtractYear(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+    case class OnlyDayOfWeek(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractDayOfWeek(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+    case class OnlyWeekOfYear(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractWeekOfYear(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+    case class OnlyIsoYear(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractIsoYear(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
     }
 
     private object FixedNow {
@@ -142,6 +161,18 @@ class SoQLExprSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with ({ ty
           Some(OnlyMonth(zoneName))
         case FunctionCall(MonomorphicFunctions.FloatingTimestampDayField, Seq(FloatNow(zoneName))) =>
           Some(OnlyDay(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampDayOfWeekField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyDayOfWeek(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampExtractDoW, Seq(FloatNow(zoneName))) =>
+          Some(OnlyDayOfWeek(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampWeekOfYearField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyDayOfWeek(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampExtractWoY, Seq(FloatNow(zoneName))) =>
+          Some(OnlyDayOfWeek(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampIsoYearField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyIsoYear(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampExtractIsoY, Seq(FloatNow(zoneName))) =>
+          Some(OnlyIsoYear(zoneName))
         case _ =>
           None
       }

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExprSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLExprSqlizer.scala
@@ -1,0 +1,180 @@
+package com.socrata.pg.analyzer2
+
+import java.math.{BigDecimal => JBigDecimal}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.sqlizer._
+import com.socrata.soql.types.{SoQLType, SoQLValue, SoQLText, SoQLFloatingTimestamp, SoQLDate, SoQLNumber}
+import com.socrata.soql.functions.{SoQLFunctions, SoQLTypeInfo}
+
+import com.socrata.pg.analyzer2.metatypes.DatabaseNamesMetaTypes
+
+class SoQLExprSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with ({ type ColumnType = SoQLType; type ColumnValue = SoQLValue; type ExtraContext = SoQLExtraContext })] extends ExprSqlizer[MT](
+  new SoQLFunctionSqlizer[MT],
+  new SoQLExprSqlFactory[MT]
+) {
+  import SoQLTypeInfo.hasType
+
+  private object MonomorphicFunctions {
+    val GetUtcDate = SoQLFunctions.GetUtcDate.monomorphic.get
+    val ToFloatingTimestamp = SoQLFunctions.ToFloatingTimestamp.monomorphic.get
+
+    val FloatingTimestampTruncYmd = SoQLFunctions.FloatingTimeStampTruncYmd.monomorphic.get
+    val FloatingTimestampTruncYm = SoQLFunctions.FloatingTimeStampTruncYm.monomorphic.get
+    val FloatingTimestampTruncY = SoQLFunctions.FloatingTimeStampTruncY.monomorphic.get
+
+    val FixedTimestampZTruncYmd = SoQLFunctions.FixedTimeStampZTruncYmd.monomorphic.get
+    val FixedTimestampZTruncYm = SoQLFunctions.FixedTimeStampZTruncYm.monomorphic.get
+    val FixedTimestampZTruncY = SoQLFunctions.FixedTimeStampZTruncY.monomorphic.get
+
+    val FixedTimestampTruncYmdAtTimeZone = SoQLFunctions.FixedTimeStampTruncYmdAtTimeZone.monomorphic.get
+    val FixedTimestampTruncYmAtTimeZone = SoQLFunctions.FixedTimeStampTruncYmAtTimeZone.monomorphic.get
+    val FixedTimestampTruncYAtTimeZone = SoQLFunctions.FixedTimeStampTruncYAtTimeZone.monomorphic.get
+
+    val FloatingTimestampYearField = SoQLFunctions.FloatingTimestampYearField.monomorphic.get
+    val FloatingTimestampMonthField = SoQLFunctions.FloatingTimestampMonthField.monomorphic.get
+    val FloatingTimestampDayField = SoQLFunctions.FloatingTimestampDayField.monomorphic.get
+
+    val FloatingTimestampDateField = SoQLFunctions.FloatingTimestampDateField.monomorphic.get
+  }
+
+  private sealed abstract class NowInZone {
+    val zoneName: String
+
+    def asExpr(tsp: TimestampProvider, pos: PositionInfo): Option[LiteralValue]
+  }
+  private object NowInZone {
+    case class FullPrecision(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowInZone(zoneName).map { v => LiteralValue[MT](SoQLFloatingTimestamp(v))(pos.asAtomic) }
+    }
+    case class DayPrecision(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowTruncDay(zoneName).map { v => LiteralValue[MT](SoQLFloatingTimestamp(v))(pos.asAtomic) }
+    }
+    case class MonthPrecision(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowTruncMonth(zoneName).map { v => LiteralValue[MT](SoQLFloatingTimestamp(v))(pos.asAtomic) }
+    }
+    case class YearPrecision(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowTruncYear(zoneName).map { v => LiteralValue[MT](SoQLFloatingTimestamp(v))(pos.asAtomic) }
+    }
+    case class Date(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowDate(zoneName).map { v => LiteralValue[MT](SoQLDate(v))(pos.asAtomic) }
+    }
+    case class OnlyDay(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractDay(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+    case class OnlyMonth(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractMonth(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+    case class OnlyYear(zoneName: String) extends NowInZone {
+      override def asExpr(tsp: TimestampProvider, pos: PositionInfo) =
+        tsp.nowExtractYear(zoneName).map { v => LiteralValue[MT](SoQLNumber(new JBigDecimal(v)))(pos.asAtomic) }
+    }
+
+    private object FixedNow {
+      def unapply(e: Expr): Boolean = {
+        e match {
+          case FunctionCall(MonomorphicFunctions.GetUtcDate, Seq()) =>
+            true
+          case _ =>
+            false
+        }
+      }
+    }
+
+    private object LiteralZone {
+      def unapply(e: Expr): Option[String] = {
+        e match {
+          case LiteralValue(SoQLText(s)) =>
+            Some(s)
+          case _ =>
+            None
+        }
+      }
+    }
+
+    private object FloatNow {
+      def unapply(e: Expr): Option[String] = {
+        e match {
+          case FunctionCall(MonomorphicFunctions.ToFloatingTimestamp, Seq(FixedNow(), LiteralZone(zoneName))) =>
+            Some(zoneName)
+          case _ =>
+            None
+        }
+      }
+    }
+
+    def unapply(e: Expr): Option[NowInZone] = {
+      e match {
+        case FloatNow(zoneName) =>
+          Some(FullPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampTruncYmd, Seq(FloatNow(zoneName))) =>
+          Some(DayPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampTruncYm, Seq(FloatNow(zoneName))) =>
+          Some(MonthPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampTruncY, Seq(FloatNow(zoneName))) =>
+          Some(YearPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampZTruncYmd, Seq(FixedNow())) =>
+          Some(DayPrecision("UTC"))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampZTruncYm, Seq(FixedNow())) =>
+          Some(MonthPrecision("UTC"))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampZTruncY, Seq(FixedNow())) =>
+          Some(YearPrecision("UTC"))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampTruncYmdAtTimeZone, Seq(FixedNow(), LiteralZone(zoneName))) =>
+          Some(DayPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampTruncYmAtTimeZone, Seq(FixedNow(), LiteralZone(zoneName))) =>
+          Some(MonthPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FixedTimestampTruncYAtTimeZone, Seq(FixedNow(), LiteralZone(zoneName))) =>
+          Some(YearPrecision(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampDateField, Seq(FloatNow(zoneName))) =>
+          Some(Date(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampDateField, Seq(FloatNow(zoneName))) =>
+          Some(Date(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampYearField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyYear(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampMonthField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyMonth(zoneName))
+        case FunctionCall(MonomorphicFunctions.FloatingTimestampDayField, Seq(FloatNow(zoneName))) =>
+          Some(OnlyDay(zoneName))
+        case _ =>
+          None
+      }
+    }
+  }
+
+  private class SoQLContextedExprSqlizer(
+    availableSchemas: AvailableSchemas,
+    selectListIndices: IndexedSeq[SelectListIndex],
+    sqlizerCtx: Sqlizer.DynamicContext[MT]
+  ) extends DefaultContextedExprSqlizer(availableSchemas, selectListIndices, sqlizerCtx) {
+    override def sqlize(e: Expr): ExprSql = {
+      // The FuncallSqlizer operates bottom-up, so if we want to do
+      // some kinds of optimization - in particular, if we want to
+      // notice that only a coarse part of a call to `get_utc_date()`
+      // is used - we need to intercept it on the way down, which
+      // happens here.
+      e match {
+        case expr@NowInZone(thing) =>
+          thing.asExpr(sqlizerCtx.extraContext.timestampProvider, expr.position) match {
+            case Some(replacement) => super.sqlize(replacement)
+            case None => super.sqlize(expr)
+          }
+        case other => super.sqlize(other)
+      }
+    }
+  }
+
+  override def withContext(
+    availableSchemas: AvailableSchemas,
+    selectListIndices: IndexedSeq[SelectListIndex],
+    sqlizerCtx: Sqlizer.DynamicContext[MT]
+  ): ExprSqlizer.Contexted[MT] =
+    new SoQLContextedExprSqlizer(availableSchemas, selectListIndices, sqlizerCtx)
+
+}

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizer.scala
@@ -224,7 +224,7 @@ class SoQLFunctionSqlizer[MT <: MetaTypes with metatypes.SoQLMetaTypesExt with (
     assert(args.length == 0)
 
     ctx.repFor(f.typ).
-      literal(LiteralValue[MT](SoQLFixedTimestamp(ctx.extraContext.now))(AtomicPositionInfo.Synthetic)).
+      literal(LiteralValue[MT](SoQLFixedTimestamp(ctx.extraContext.timestampProvider.now))(AtomicPositionInfo.Synthetic)).
       withExpr(f)
   }
 

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLSqlizer.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/SoQLSqlizer.scala
@@ -9,10 +9,7 @@ import com.socrata.datacoordinator.common
 import com.socrata.pg.analyzer2.metatypes.{DatabaseNamesMetaTypes, AugmentedTableName}
 
 object SoQLSqlizer extends Sqlizer[DatabaseNamesMetaTypes](
-  new ExprSqlizer(
-    new SoQLFunctionSqlizer[DatabaseNamesMetaTypes],
-    new SoQLExprSqlFactory[DatabaseNamesMetaTypes]
-  ),
+  new SoQLExprSqlizer,
   Namespaces,
   new SoQLRewriteSearch[DatabaseNamesMetaTypes](searchBeforeQuery = true),
   DatabaseNamesMetaTypes.provenanceMapper,

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/TimestampProvider.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/TimestampProvider.scala
@@ -28,6 +28,9 @@ trait TimestampProvider {
   def nowExtractDay(zoneName: String): Option[Int]
   def nowExtractMonth(zoneName: String): Option[Int]
   def nowExtractYear(zoneName: String): Option[Int]
+  def nowExtractDayOfWeek(zoneName: String): Option[Int]
+  def nowExtractWeekOfYear(zoneName: String): Option[Int]
+  def nowExtractIsoYear(zoneName: String): Option[Int]
 
   def finish(): TimestampUsage
 }
@@ -58,6 +61,9 @@ object TimestampProvider {
     override def nowExtractDay(zoneName: String) = explode()
     override def nowExtractMonth(zoneName: String) = explode()
     override def nowExtractYear(zoneName: String) = explode()
+    override def nowExtractDayOfWeek(zoneName: String) = explode()
+    override def nowExtractWeekOfYear(zoneName: String) = explode()
+    override def nowExtractIsoYear(zoneName: String) = explode()
     override def finish() = TimestampUsage.NoUsage
   }
 
@@ -87,7 +93,6 @@ object TimestampProvider {
     protected def nowInZoneIntl(name: String): Option[LocalDateTime]
 
     override final def now = {
-      nowUsed = true
       cached[DateTime]("now", _.getMillis.toString)(Some(actualNow)).get
     }
 
@@ -129,6 +134,21 @@ object TimestampProvider {
     override final def nowExtractYear(zoneName: String) =
       cached[Int]("year", _.toString) {
         nowInZoneIntl(zoneName).map(_.getYear)
+      }
+
+    override final def nowExtractDayOfWeek(zoneName: String) =
+      cached[Int]("dow", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getDayOfWeek)
+      }
+
+    override final def nowExtractWeekOfYear(zoneName: String) =
+      cached[Int]("woy", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getWeekOfWeekyear)
+      }
+
+    override final def nowExtractIsoYear(zoneName: String) =
+      cached[Int]("isoyear", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getWeekyear)
       }
 
     override final def finish() = {

--- a/common-pg/src/main/scala/com/socrata/pg/analyzer2/TimestampProvider.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/analyzer2/TimestampProvider.scala
@@ -1,0 +1,169 @@
+package com.socrata.pg.analyzer2
+
+import scala.collection.{mutable => scm}
+
+import java.sql.Connection
+
+import com.rojoma.json.v3.ast.{JObject, JString}
+import com.rojoma.json.v3.io.CompactJsonWriter
+import org.joda.time.{DateTime, DateTimeZone, LocalDateTime, LocalDate}
+import org.joda.time.format.ISODateTimeFormat
+
+trait TimestampProvider {
+  def now: DateTime
+
+  def nowInZone(zoneName: String): Option[LocalDateTime]
+  def nowTruncDay(zoneName: String): Option[LocalDateTime]
+  def nowTruncMonth(zoneName: String): Option[LocalDateTime]
+  def nowTruncYear(zoneName: String): Option[LocalDateTime]
+  def nowDate(zoneName: String): Option[LocalDate]
+  def nowExtractDay(zoneName: String): Option[Int]
+  def nowExtractMonth(zoneName: String): Option[Int]
+  def nowExtractYear(zoneName: String): Option[Int]
+
+  def finish(): TimestampUsage
+}
+
+trait TimestampUsage {
+  val etagInfo: Option[String]
+  val effectiveLastModified: Option[DateTime]
+}
+object TimestampUsage {
+  object NoUsage extends TimestampUsage {
+    override val etagInfo = None
+    override val effectiveLastModified = None
+  }
+}
+
+object TimestampProvider {
+  // This is used by the rollup manager; get_utc_time is forbidden in
+  // rollups and any use of it should have been caught beforehand.
+  object Forbid extends TimestampProvider {
+    private def explode(): Nothing =
+      throw new Exception("get_utc_time() should not have been used in this context")
+    override def now = explode()
+    override def nowInZone(zoneName: String) = explode()
+    override def nowTruncDay(zoneName: String) = explode()
+    override def nowTruncMonth(zoneName: String) = explode()
+    override def nowTruncYear(zoneName: String) = explode()
+    override def nowDate(zoneName: String) = explode()
+    override def nowExtractDay(zoneName: String) = explode()
+    override def nowExtractMonth(zoneName: String) = explode()
+    override def nowExtractYear(zoneName: String) = explode()
+    override def finish() = TimestampUsage.NoUsage
+  }
+
+  // This is used in tests.  We don't have a database connection to
+  // run against, so instead just implement it in terms of joda-time's
+  // timezone database.
+  class InProcess extends TimestampProvider {
+    private val tracker = new scm.TreeMap[String, (Any, String)]
+
+    private def cached[T](tag: String, f: T => String)(value: => Option[T]): Option[T] = {
+      tracker.get(tag) match {
+        case Some((x, _)) =>
+          Some(x.asInstanceOf[T])
+        case None =>
+          val result: Option[T] = value
+          result.foreach { r =>
+            tracker += tag -> (result, f(r))
+          }
+          result
+      }
+    }
+
+    private val actualNow = DateTime.now().withZone(DateTimeZone.UTC).withMillisOfSecond(0)
+    private var nowUsed = false
+
+    private def zone(name: String): Option[DateTimeZone] =
+      try {
+        Some(DateTimeZone.forID(name))
+      } catch {
+        case e: IllegalArgumentException =>
+          None
+      }
+
+    private def nowInZoneIntl(name: String) = {
+      nowUsed = true
+      zone(name).map { z => actualNow.withZone(z).toLocalDateTime }
+    }
+
+    override def now = {
+      nowUsed = true
+      cached[DateTime]("now", _.getMillis.toString)(Some(actualNow)).get
+    }
+
+    private def iso(ldt: LocalDateTime): String = ISODateTimeFormat.dateTime.print(ldt)
+    private def isoDate(ld: LocalDate): String = ISODateTimeFormat.date.print(ld)
+
+    override def nowInZone(zoneName: String) =
+      cached("now/" + zoneName, iso) { nowInZoneIntl(zoneName) }
+
+    override def nowTruncDay(zoneName: String) = {
+      cached("trunc day/" + zoneName, iso) { nowInZoneIntl(zoneName).map(_.withTime(0, 0, 0, 0)) }
+    }
+
+    override def nowTruncMonth(zoneName: String) =
+      cached("trunc month/" + zoneName, iso) {
+        nowInZoneIntl(zoneName).map(_.withTime(0, 0, 0, 0).withDayOfMonth(1))
+      }
+
+    override def nowTruncYear(zoneName: String) =
+      cached("trunc year/" + zoneName, iso) {
+        nowInZoneIntl(zoneName).map(_.withTime(0, 0, 0, 0).withDayOfMonth(1).withMonthOfYear(1))
+      }
+
+    override def nowDate(zoneName: String) =
+      cached("date/" + zoneName, isoDate) {
+        nowInZoneIntl(zoneName).map(_.toLocalDate)
+      }
+
+    override def nowExtractDay(zoneName: String) =
+      cached[Int]("day", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getDayOfMonth)
+      }
+
+    override def nowExtractMonth(zoneName: String) =
+      cached[Int]("month", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getMonthOfYear)
+      }
+
+    override def nowExtractYear(zoneName: String) =
+      cached[Int]("year", _.toString) {
+        nowInZoneIntl(zoneName).map(_.getYear)
+      }
+
+    override def finish() = {
+      new TimestampUsage {
+        override val etagInfo: Option[String] =
+          Some(CompactJsonWriter.toString(JObject(tracker.mapValues { v => JString(v._2) })))
+
+        override val effectiveLastModified: Option[DateTime] =
+          if(nowUsed) None
+          else Some(actualNow)
+      }
+    }
+  }
+
+  class Postgresql(conn: Connection) extends TimestampProvider {
+    private def explode(): Nothing =
+      throw new Exception("get_utc_time() should not have been used in this context")
+
+    private val actualNow = DateTime.now().withZone(DateTimeZone.UTC).withMillisOfSecond(0)
+    private var nowUsed = false
+
+    def now: DateTime = {
+      nowUsed = true
+      actualNow
+    }
+    override def nowInZone(zoneName: String) = explode()
+    override def nowTruncDay(zoneName: String) = explode()
+    override def nowTruncMonth(zoneName: String) = explode()
+    override def nowTruncYear(zoneName: String) = explode()
+    override def nowDate(zoneName: String) = explode()
+    override def nowExtractDay(zoneName: String) = explode()
+    override def nowExtractMonth(zoneName: String) = explode()
+    override def nowExtractYear(zoneName: String) = explode()
+    override def finish() = explode()
+  }
+}

--- a/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
+++ b/common-pg/src/main/scala/com/socrata/pg/store/RollupManager.scala
@@ -17,7 +17,7 @@ import com.socrata.datacoordinator.truth.metadata.{ColumnInfo, CopyInfo, Lifecyc
 import com.socrata.datacoordinator.truth.sql.SqlColumnRep
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.pg.analyzer2.metatypes.{RollupMetaTypes, DatabaseNamesMetaTypes, AugmentedTableName}
-import com.socrata.pg.analyzer2.{SqlNormalizer, SoQLRewriteSearch, SoQLExtraContext}
+import com.socrata.pg.analyzer2.{SqlNormalizer, SoQLRewriteSearch, SoQLExtraContext, TimestampProvider}
 import com.socrata.pg.error.RowSizeBufferSqlErrorContinue
 import com.socrata.pg.soql._
 import com.socrata.pg.soql.SqlizerContext.SqlizerContext
@@ -187,7 +187,7 @@ class RollupManager(pgu: PGSecondaryUniverse[SoQLType, SoQLValue], copyInfo: Cop
           case Some((foundTables, analysis, locationSubcolumns, cryptProviders)) =>
             val sqlizer = SoQLSqlizer
 
-            val (denormSql, augSchema, _) = sqlizer.sqlize(analysis, rewriteOutputColumns = false, new SoQLExtraContext(Map.empty, cryptProviders, locationSubcolumns, SqlUtils.escapeString(pgu.conn, _))) match {
+            val (denormSql, augSchema, _) = sqlizer.sqlize(analysis, rewriteOutputColumns = false, new SoQLExtraContext(Map.empty, cryptProviders, locationSubcolumns, SqlUtils.escapeString(pgu.conn, _), TimestampProvider.Forbid)) match {
               case Right(result) => result
               case Left(nothing) => nothing
             }

--- a/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
+++ b/common-pg/src/test/scala/com/socrata/pg/analyzer2/SoQLFunctionSqlizerTest.scala
@@ -95,7 +95,8 @@ class SoQLFunctionSqlizerTest extends FunSuite with MustMatchers with SqlizerUni
       def allProviders = Map.empty
     },
     Map.empty,
-    JString(_).toString
+    JString(_).toString,
+    new TimestampProvider.InProcess
   )
 
   // The easiest way to make an Expr for sqlization is just to analyze

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ETagify.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ETagify.scala
@@ -34,7 +34,7 @@ object ETagify extends StatementUniverse[InputMetaTypes] {
     passes: Seq[Seq[rewrite.Pass]],
     allowRollups: Boolean,
     debug: Option[Debug],
-    now: Option[DateTime]
+    timestampUsage: Option[String]
   ): EntityTag = {
     val hasher = Hasher.newSha256()
 
@@ -69,8 +69,8 @@ object ETagify extends StatementUniverse[InputMetaTypes] {
     log.debug("Mixing in debug: {}", debug)
     hasher.hash(debug)
 
-    log.debug("Mixing in now: {}", now)
-    hasher.hash(now.map(_.getMillis))
+    log.debug("Mixing in timestamp usage: {}", timestampUsage)
+    hasher.hash(timestampUsage)
 
     // Should this be strong or weak?  I'm choosing weak here because
     // I don't think we actually guarantee two calls will be

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ProcessQuery.scala
@@ -236,7 +236,7 @@ class ProcessQuery(resultCache: ResultCache, timeoutManager: ProcessQuery.Timeou
             copyCache
           ),
           SqlUtils.escapeString(pgu.conn, _),
-          new TimestampProvider.InProcess
+          new TimestampProvider.Postgresql(pgu.conn)
         )
       ) match {
         case Right(result) => (nameAnalysis, result)


### PR DESCRIPTION
Before:
* calling `get_utc_date` would make your query's `Last-Modified` and `ETag` headers change every second

Now:
* `Last-Modified` still changes every second, but the `ETag` (and hence also the automatic response cache) will take into account certain "coarsening" function calls surrounding the `get_utc_date` call.  In particular, if you _immediately_ convert the result of `get_utc_date` into a `floating_timestamp` in some literal time zone and then use any of the `date_extract_...` functions or any of the field accessors that return values at day-resolution or coarser, the etag will be computed with that coarsened value instead.
