### PR TITLE
EN-76223: deploy to ECS as well as marathon

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,7 +198,7 @@ pipeline {
                   ]
                   createBuild(
                     buildInfo,
-                    rmsSupportedEnvironment.production
+                    rmsSupportedEnvironment.development //production
                   )
                 }
               }
@@ -232,7 +232,7 @@ pipeline {
                   ]
                   createBuild(
                     buildInfo,
-                    rmsSupportedEnvironment.production
+                    rmsSupportedEnvironment.development // production
                   )
                 }
               }
@@ -268,6 +268,14 @@ pipeline {
                 environment: env.ENVIRONMENT,
                 waitTime: '60'
               )
+              // While working on migrating from marathon to ECS, we are keeping the tagged images up to date
+              // Once the migration is done, we will remove the marathonDeploy and leave in place this publish which triggers the ECS deployment
+              env.TARGET_DEPLOY_TAG = (env.ENVIRONMENT == 'rc') ? 'rc' : 'latest'
+              dockerize_server.publish(
+                sourceTag: env.DOCKER_TAG,
+                targetTag: env.TARGET_DEPLOY_TAG,
+                environments: ['internal']
+              )
             }
           }
           post {
@@ -280,7 +288,7 @@ pipeline {
                   ]
                   createDeployment(
                     deployInfo,
-                    rmsSupportedEnvironment.production
+                    rmsSupportedEnvironment.development //production
                   )
                 }
               }
@@ -296,6 +304,13 @@ pipeline {
                 tag: env.SECONDARY_BUILD_ID,
                 environment: env.ENVIRONMENT,
               )
+              // While working on migrating from marathon to ECS, we are keeping the tagged images up to date
+              // Once the migration is done, we will remove the marathonDeploy and leave in place this publish which triggers the ECS deployment
+              dockerize_secondary.publish(
+                sourceTag: env.SECONDARY_DOCKER_TAG,
+                targetTag: env.TARGET_DEPLOY_TAG,
+                environments: ['internal']
+              )
             }
           }
           post {
@@ -308,7 +323,7 @@ pipeline {
                   ]
                   createDeployment(
                     deployInfo,
-                    rmsSupportedEnvironment.production
+                    rmsSupportedEnvironment.development //production
                   )
                 }
               }


### PR DESCRIPTION
While working on migrating from marathon to ECS, we are keeping the tagged images up to date. This commit adds the mechanism for the ECS deployment in addition to the marathon deployment. Once the migration is done, we will remove the marathonDeploy and leave in place the ECS deployment.