### PR TITLE
ECS shutdown experiment

### DIFF
--- a/soql-server-pg/docker/ship.d/run
+++ b/soql-server-pg/docker/ship.d/run
@@ -23,19 +23,39 @@ su socrata -c '/usr/bin/java \
     com.socrata.soql-server-pg.migrations \
     '
 
-exec su socrata -c 'exec /usr/bin/java \
-    -Xmx${JAVA_XMX} \
-    -Xms${JAVA_XMX} \
-    -Dconfig.file=${SERVER_CONFIG} \
-    -Djava.net.preferIPv4Stack=true \
-    -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
-    -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
-    -Dcom.sun.management.jmxremote.ssl=false \
-    -Dcom.sun.management.jmxremote.authenticate=false \
-    -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
-    -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
-    ${JAVA_GC_LOG_BEHAVIOR} \
-    ${JAVA_OOM_BEHAVIOR} \
-    -jar $SERVER_ARTIFACT \
-    com.socrata.pg.server.QueryServer \
-    '
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+   # running in ECS - don't bother switching user, in order to see if
+   # we actually receive the shutdown SIGTERM ECS sends us this way.
+   exec /usr/bin/java \
+        -Xmx${JAVA_XMX} \
+        -Xms${JAVA_XMX} \
+        -Dconfig.file=${SERVER_CONFIG} \
+        -Djava.net.preferIPv4Stack=true \
+        -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.ssl=false \
+        -Dcom.sun.management.jmxremote.authenticate=false \
+        -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
+        -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
+        ${JAVA_GC_LOG_BEHAVIOR} \
+        ${JAVA_OOM_BEHAVIOR} \
+        -jar $SERVER_ARTIFACT \
+        com.socrata.pg.server.QueryServer
+else
+    exec su socrata -c 'exec /usr/bin/java \
+        -Xmx${JAVA_XMX} \
+        -Xms${JAVA_XMX} \
+        -Dconfig.file=${SERVER_CONFIG} \
+        -Djava.net.preferIPv4Stack=true \
+        -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.ssl=false \
+        -Dcom.sun.management.jmxremote.authenticate=false \
+        -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
+        -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
+        ${JAVA_GC_LOG_BEHAVIOR} \
+        ${JAVA_OOM_BEHAVIOR} \
+        -jar $SERVER_ARTIFACT \
+        com.socrata.pg.server.QueryServer \
+        '
+fi

--- a/store-pg/docker/ship.d/run
+++ b/store-pg/docker/ship.d/run
@@ -19,19 +19,38 @@ else
   /bin/env_parse ${SECONDARY_CONFIG}.j2
 fi
 
-exec su socrata -c 'exec /usr/bin/java \
-    -Xmx${JAVA_XMX} \
-    -Xms${JAVA_XMX} \
-    -Dconfig.file=${SERVER_ROOT}/${SERVER_CONFIG} \
-    -Djava.net.preferIPv4Stack=true \
-    -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
-    -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
-    -Dcom.sun.management.jmxremote.ssl=false \
-    -Dcom.sun.management.jmxremote.authenticate=false \
-    -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
-    -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
-    -XX:+ExitOnOutOfMemoryError \
-    -XX:+HeapDumpOnOutOfMemoryError \
-    -XX:HeapDumpPath=/mnt/mesos/sandbox \
-    -jar $SERVER_ARTIFACT
-    '
+if [ -n "$ECS_CONTAINER_METADATA_URI_V4" ]; then
+   # running in ECS - don't bother switching user
+    exec /usr/bin/java \
+         -Xmx${JAVA_XMX} \
+         -Xms${JAVA_XMX} \
+         -Dconfig.file=${SERVER_ROOT}/${SERVER_CONFIG} \
+         -Djava.net.preferIPv4Stack=true \
+         -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+         -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+         -Dcom.sun.management.jmxremote.ssl=false \
+         -Dcom.sun.management.jmxremote.authenticate=false \
+         -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
+         -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
+         -XX:+ExitOnOutOfMemoryError \
+         -XX:+HeapDumpOnOutOfMemoryError \
+         -XX:HeapDumpPath=/mnt/mesos/sandbox \
+         -jar $SERVER_ARTIFACT
+else
+    exec su socrata -c 'exec /usr/bin/java \
+        -Xmx${JAVA_XMX} \
+        -Xms${JAVA_XMX} \
+        -Dconfig.file=${SERVER_ROOT}/${SERVER_CONFIG} \
+        -Djava.net.preferIPv4Stack=true \
+        -Dcom.sun.management.jmxremote.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.rmi.port=${JMX_PORT} \
+        -Dcom.sun.management.jmxremote.ssl=false \
+        -Dcom.sun.management.jmxremote.authenticate=false \
+        -Djava.rmi.server.hostname=${ARK_HOST:-localhost} \
+        -XX:MaxMetaspaceSize=${JAVA_MAX_METASPACE} \
+        -XX:+ExitOnOutOfMemoryError \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath=/mnt/mesos/sandbox \
+        -jar $SERVER_ARTIFACT
+        '
+fi


### PR DESCRIPTION
When I was doing the Redis thing last week, I noticed that we're still apparently not shutting down properly in ECS.  Best guess is that sudo is eating the SIGTERM that ECS is supposed to send us when a shutdown is initiated.  So, let's see if that's the case by _not_ switching user if we're ECSified.