### PR TITLE
EN-79631: Log time-saved info when reporting a query was served from …

### DIFF
--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Nanoseconds.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/Nanoseconds.scala
@@ -1,0 +1,14 @@
+package com.socrata.pg.server.analyzer2
+
+class Nanoseconds(val ns: Long) extends AnyVal {
+  def toMilliseconds: Long = ns / 1000000L
+}
+
+class MonotonicTime private (private val ns: Long) extends AnyVal {
+  def -(that: MonotonicTime) = new Nanoseconds(this.ns - that.ns)
+  def elapsed() = MonotonicTime.now() - this
+}
+
+object MonotonicTime {
+  def now() = new MonotonicTime(System.nanoTime())
+}

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/NoopResultCache.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/NoopResultCache.scala
@@ -10,7 +10,7 @@ import com.socrata.http.server.util.EntityTag
 object NoopResultCache extends ResultCache {
   override def apply(etag: EntityTag) = None
 
-  override def cachingOutputStream(underlying: OutputStream, etag: EntityTag, lastModified: DateTime, contentType: String): Managed[OutputStream] =
+  override def cachingOutputStream(underlying: OutputStream, etag: EntityTag, lastModified: DateTime, contentType: String, startTime: MonotonicTime): Managed[OutputStream] =
     new Managed[OutputStream] {
       override def run[T](f: OutputStream => T): T = f(underlying)
     }

--- a/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ResultCache.scala
+++ b/soql-server-pg/src/main/scala/com/socrata/pg/server/analyzer2/ResultCache.scala
@@ -9,7 +9,7 @@ import com.socrata.http.server.util.EntityTag
 
 trait ResultCache {
   def apply(key: EntityTag): Option[ResultCache.Result]
-  def cachingOutputStream(underlying: OutputStream, etag: EntityTag, lastModified: DateTime, contentType: String): Managed[OutputStream]
+  def cachingOutputStream(underlying: OutputStream, etag: EntityTag, lastModified: DateTime, contentType: String, startTime: MonotonicTime): Managed[OutputStream]
 
   // An outputstream that forwards to `underlying`, but will save up
   // to `limit` written bytes, which can be retrieved by calling
@@ -81,5 +81,5 @@ trait ResultCache {
 }
 
 object ResultCache {
-  case class Result(etag: EntityTag, lastModified: DateTime, contentType: String, body: OutputStream => Unit)
+  case class Result(etag: EntityTag, lastModified: DateTime, contentType: String, originalDurationMS: Long, body: OutputStream => Unit)
 }


### PR DESCRIPTION
…cache

Now we record how long it took to process the query on the first run and display original vs cached times when we serve a result from cache, so we can get some rough numbers about how much time is actually saved by it.

They're rough numbers because lots of things can change between runs that would affect an uncached query's speed: whether the dataset(s) being queried are already in postgres's RAM, whether hotspot is still optimizing the soql server's hot codepaths, etc.